### PR TITLE
feat: add IsQuadraticExtension instance for Q(√d)/ℚ

### DIFF
--- a/Lean/QuadraticNumberFields/Instances.lean
+++ b/Lean/QuadraticNumberFields/Instances.lean
@@ -5,7 +5,6 @@ Authors: Frankie Wang
 -/
 import QuadraticNumberFields.Param
 import Mathlib.NumberTheory.NumberField.Basic
-import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 /-!
 # Field and Number Field Instances


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces the `Algebra.IsQuadraticExtension` instance for `QuadraticNumberFields d` over `ℚ`. This formally establishes that `Q(√d)` is a degree-2 field extension of the rational numbers `ℚ`, integrating it with `mathlib`'s algebraic hierarchy.

To support this, a private theorem `module_eq` was added. This theorem proves that the `Module ℚ` instance derived from the `Field` algebra structure on `Q(√d)` is equivalent to the `QuadraticAlgebra` module structure, resolving a potential diamond problem. This `module_eq` theorem is then utilized in the proof of the new `IsQuadraticExtension` instance and also refactors the existing `NumberField` instance.
<!-- kody-pr-summary:end -->