### PR TITLE
feat: generalize mathlib Zsqrtd negative-d instances

### DIFF
--- a/Lean/QuadraticNumberFields.lean
+++ b/Lean/QuadraticNumberFields.lean
@@ -6,6 +6,7 @@ import QuadraticNumberFields.Instances
 import QuadraticNumberFields.Euclidean.Basic
 import QuadraticNumberFields.RingOfIntegers.ModFour
 import QuadraticNumberFields.RingOfIntegers.Zsqrtd
+import QuadraticNumberFields.RingOfIntegers.ZsqrtdMathlibInstances
 import QuadraticNumberFields.RingOfIntegers.HalfInt
 import QuadraticNumberFields.RingOfIntegers.ZOnePlusSqrtOverTwo
 import QuadraticNumberFields.RingOfIntegers.Integrality

--- a/Lean/QuadraticNumberFields/Examples/ZsqrtdNeg5/Ideals.lean
+++ b/Lean/QuadraticNumberFields/Examples/ZsqrtdNeg5/Ideals.lean
@@ -6,7 +6,7 @@ Authors: Frankie Wang
 Ideal factorization and primality results for ℤ[√-5].
 Ported from the ANT project.
 -/
-import QuadraticNumberFields.Examples.ZsqrtdNeg5.Basic
+import QuadraticNumberFields.RingOfIntegers.ZsqrtdMathlibInstances
 import Mathlib.RingTheory.Ideal.Operations
 import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 import Mathlib.Tactic.NormNum

--- a/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
@@ -2,12 +2,24 @@
 Copyright (c) 2026 Frankie Wang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frankie Wang
-
-General instances for `ℤ[√d]` when `d < 0`: no zero divisors and integral domain.
 -/
 import Mathlib.NumberTheory.Zsqrtd.Basic
 
-open Zsqrtd
+/-!
+# Additional Instances for mathlib `Zsqrtd`
+
+This module adds generic algebraic instances for mathlib's `_root_.Zsqrtd d`
+under the hypothesis `d < 0`.
+
+## Main Definitions
+
+* `Zsqrtd.instNoZeroDivisors`: `NoZeroDivisors (Zsqrtd d)` for `d < 0`.
+* `Zsqrtd.instIsDomain`: `IsDomain (Zsqrtd d)` for `d < 0`.
+
+## Main Theorems
+
+* No new named theorems are introduced in this file.
+-/
 
 namespace Zsqrtd
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new module, `ZsqrtdMathlibInstances`, to generalize and centralize algebraic instances for `mathlib`'s `Zsqrtd d` type.

Specifically, this module provides `NoZeroDivisors` and `IsDomain` instances for `Zsqrtd d` under the hypothesis that `d < 0`. This refactors existing instances, moving them from specific example files (e.g., `ZsqrtdNeg5`) to this new, more general module, thereby improving code organization and reusability.
<!-- kody-pr-summary:end -->