### PR TITLE
feat: add Dedekind structure for Zsqrtd

### DIFF
--- a/Lean/QuadraticNumberFields.lean
+++ b/Lean/QuadraticNumberFields.lean
@@ -3,6 +3,7 @@ import QuadraticNumberFields.Rescale
 import QuadraticNumberFields.Param
 import QuadraticNumberFields.ParamUniqueness
 import QuadraticNumberFields.Instances
+import QuadraticNumberFields.RingEquiv
 import QuadraticNumberFields.Euclidean.Basic
 import QuadraticNumberFields.RingOfIntegers.ModFour
 import QuadraticNumberFields.RingOfIntegers.Zsqrtd

--- a/Lean/QuadraticNumberFields/RingEquiv.lean
+++ b/Lean/QuadraticNumberFields/RingEquiv.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+import Mathlib.RingTheory.DedekindDomain.Basic
+import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
+import Mathlib.RingTheory.Noetherian.Basic
+
+/-!
+# Ring Equivalence Transport Lemmas
+
+This file contains generic lemmas for transporting algebraic properties across
+ring equivalences.
+
+## Main Definitions
+
+* `RingEquiv.dimensionLEOne`: transport `Ring.DimensionLEOne` across a ring
+  equivalence.
+* `RingEquiv.isDedekindDomain`: transport `IsDedekindDomain` across a ring
+  equivalence.
+
+## Main Theorems
+
+* `RingEquiv.isDedekindDomain_iff`: `IsDedekindDomain` is invariant under ring
+  equivalence.
+-/
+
+namespace RingEquiv
+
+section CommRing
+
+variable {R S : Type*} [CommRing R] [CommRing S]
+
+/-- Transport `Ring.DimensionLEOne` across a ring equivalence. -/
+theorem dimensionLEOne (e : R ≃+* S) [Ring.DimensionLEOne R] :
+    Ring.DimensionLEOne S := by
+  refine ⟨?_⟩
+  intro p hp0 hp
+  have hcomapPrime : (Ideal.comap e p).IsPrime := Ideal.comap_isPrime e p
+  have hcomapNeBot : Ideal.comap e p ≠ ⊥ := by
+    intro hbot
+    have hmap := Ideal.map_comap_eq_self_of_equiv e p
+    rw [hbot, Ideal.map_bot] at hmap
+    exact hp0 hmap.symm
+  have hcomapMax : (Ideal.comap e p).IsMaximal :=
+    Ring.DimensionLEOne.maximalOfPrime hcomapNeBot hcomapPrime
+  letI : (Ideal.comap e p).IsMaximal := hcomapMax
+  have hmapMax : (Ideal.map e (Ideal.comap e p)).IsMaximal :=
+    Ideal.map_isMaximal_of_equiv e
+  simpa [Ideal.map_comap_eq_self_of_equiv] using hmapMax
+
+/-- Transport `IsDedekindDomain` across a ring equivalence. -/
+theorem isDedekindDomain (e : R ≃+* S) [IsDedekindDomain R] :
+    IsDedekindDomain S := by
+  letI : Module R R := Semiring.toModule
+  letI : IsNoetherianRing R :=
+    show IsNoetherian R R from IsDedekindRing.toIsNoetherian
+  letI : IsDomain S := e.toMulEquiv.isDomain_iff.mp inferInstance
+  letI : IsNoetherianRing S := isNoetherianRing_of_ringEquiv R e
+  letI : IsIntegrallyClosed S := IsIntegrallyClosed.of_equiv e
+  letI : Ring.DimensionLEOne S := dimensionLEOne e
+  letI : Module S S := Semiring.toModule
+  letI : IsDedekindRing S :=
+    { toIsNoetherian := show IsNoetherian S S from inferInstance
+      toDimensionLEOne := inferInstance
+      toIsIntegralClosure :=
+        show IsIntegralClosure S S (FractionRing S) from inferInstance }
+  infer_instance
+
+/-- `IsDedekindDomain` is invariant under ring equivalence. -/
+theorem isDedekindDomain_iff (e : R ≃+* S) :
+    IsDedekindDomain R ↔ IsDedekindDomain S := by
+  constructor
+  · intro h
+    letI : IsDedekindDomain R := h
+    exact isDedekindDomain e
+  · intro h
+    letI : IsDedekindDomain S := h
+    exact isDedekindDomain e.symm
+
+end CommRing
+
+end RingEquiv

--- a/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
@@ -73,6 +73,52 @@ theorem ringOfIntegers_equiv_zsqrtd_of_mod_four_ne_one
       intro z
       simpa [QuadraticNumberFields] using isIntegral_toQsqrtd d z)
 
+/-- If `d % 4 ≠ 1`, then `ℤ[√d]` is a Dedekind domain because it is the full
+ring of integers of `Q(√d)`. -/
+theorem isDedekindDomain_zsqrtd_of_mod_four_ne_one
+    (d : ℤ) [QuadFieldParam d]
+    (hd4 : d % 4 ≠ 1) :
+    IsDedekindDomain (Zsqrtd d) := by
+  rcases ringOfIntegers_equiv_zsqrtd_of_mod_four_ne_one d hd4 with ⟨e⟩
+  letI : Module (𝓞 (QuadraticNumberFields d)) (𝓞 (QuadraticNumberFields d)) :=
+    Semiring.toModule
+  letI : IsDedekindDomain (𝓞 (QuadraticNumberFields d)) := inferInstance
+  letI : IsNoetherianRing (𝓞 (QuadraticNumberFields d)) :=
+    show IsNoetherian (𝓞 (QuadraticNumberFields d)) (𝓞 (QuadraticNumberFields d)) from
+      IsDedekindRing.toIsNoetherian
+  letI : IsDomain (Zsqrtd d) :=
+    e.toMulEquiv.isDomain_iff.mp inferInstance
+  letI : IsNoetherianRing (Zsqrtd d) :=
+    isNoetherianRing_of_ringEquiv (𝓞 (QuadraticNumberFields d)) e
+  letI : IsIntegrallyClosed (Zsqrtd d) := IsIntegrallyClosed.of_equiv e
+  letI : Ring.DimensionLEOne (Zsqrtd d) :=
+    { maximalOfPrime := by
+        intro p hp0 hp
+        have hcomapPrime : (Ideal.comap e p).IsPrime := Ideal.comap_isPrime e p
+        have hcomapNeBot : Ideal.comap e p ≠ ⊥ := by
+          intro hbot
+          have hmap := Ideal.map_comap_eq_self_of_equiv e p
+          rw [hbot, Ideal.map_bot] at hmap
+          exact hp0 hmap.symm
+        have hcomapMax : (Ideal.comap e p).IsMaximal :=
+          Ring.DimensionLEOne.maximalOfPrime hcomapNeBot hcomapPrime
+        have hmapMax : (Ideal.map e (Ideal.comap e p)).IsMaximal :=
+          Ideal.map_isMaximal_of_equiv e
+        simpa [Ideal.map_comap_eq_self_of_equiv] using hmapMax }
+  letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
+  letI : IsDedekindRing (Zsqrtd d) :=
+    { toIsNoetherian := show IsNoetherian (Zsqrtd d) (Zsqrtd d) from inferInstance
+      toDimensionLEOne := inferInstance
+      toIsIntegralClosure :=
+        show IsIntegralClosure (Zsqrtd d) (Zsqrtd d) (FractionRing (Zsqrtd d)) from
+          inferInstance }
+  infer_instance
+
+instance instIsDedekindDomain_zsqrtd_of_mod_four_ne_one
+    (d : ℤ) [QuadFieldParam d] [Fact (d % 4 ≠ 1)] :
+    IsDedekindDomain (Zsqrtd d) :=
+  isDedekindDomain_zsqrtd_of_mod_four_ne_one d Fact.out
+
 /-- If `d % 4 = 1`, writing `d = 1 + 4k`,
 then `𝓞 (Q(√d)) ≃+* ZOnePlusSqrtOverTwo k`. -/
 theorem ringOfIntegers_equiv_zOnePlusSqrtOverTwo_of_mod_four_eq_one

--- a/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
@@ -6,6 +6,7 @@ Authors: Frankie Wang
 import QuadraticNumberFields.RingOfIntegers.Integrality
 import QuadraticNumberFields.RingOfIntegers.ModFour
 import QuadraticNumberFields.RingOfIntegers.ZOnePlusSqrtOverTwo
+import QuadraticNumberFields.RingEquiv
 
 /-!
 # Ring Of Integers Classification
@@ -80,39 +81,8 @@ theorem isDedekindDomain_zsqrtd_of_mod_four_ne_one
     (hd4 : d % 4 ≠ 1) :
     IsDedekindDomain (Zsqrtd d) := by
   rcases ringOfIntegers_equiv_zsqrtd_of_mod_four_ne_one d hd4 with ⟨e⟩
-  letI : Module (𝓞 (QuadraticNumberFields d)) (𝓞 (QuadraticNumberFields d)) :=
-    Semiring.toModule
   letI : IsDedekindDomain (𝓞 (QuadraticNumberFields d)) := inferInstance
-  letI : IsNoetherianRing (𝓞 (QuadraticNumberFields d)) :=
-    show IsNoetherian (𝓞 (QuadraticNumberFields d)) (𝓞 (QuadraticNumberFields d)) from
-      IsDedekindRing.toIsNoetherian
-  letI : IsDomain (Zsqrtd d) :=
-    e.toMulEquiv.isDomain_iff.mp inferInstance
-  letI : IsNoetherianRing (Zsqrtd d) :=
-    isNoetherianRing_of_ringEquiv (𝓞 (QuadraticNumberFields d)) e
-  letI : IsIntegrallyClosed (Zsqrtd d) := IsIntegrallyClosed.of_equiv e
-  letI : Ring.DimensionLEOne (Zsqrtd d) :=
-    { maximalOfPrime := by
-        intro p hp0 hp
-        have hcomapPrime : (Ideal.comap e p).IsPrime := Ideal.comap_isPrime e p
-        have hcomapNeBot : Ideal.comap e p ≠ ⊥ := by
-          intro hbot
-          have hmap := Ideal.map_comap_eq_self_of_equiv e p
-          rw [hbot, Ideal.map_bot] at hmap
-          exact hp0 hmap.symm
-        have hcomapMax : (Ideal.comap e p).IsMaximal :=
-          Ring.DimensionLEOne.maximalOfPrime hcomapNeBot hcomapPrime
-        have hmapMax : (Ideal.map e (Ideal.comap e p)).IsMaximal :=
-          Ideal.map_isMaximal_of_equiv e
-        simpa [Ideal.map_comap_eq_self_of_equiv] using hmapMax }
-  letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
-  letI : IsDedekindRing (Zsqrtd d) :=
-    { toIsNoetherian := show IsNoetherian (Zsqrtd d) (Zsqrtd d) from inferInstance
-      toDimensionLEOne := inferInstance
-      toIsIntegralClosure :=
-        show IsIntegralClosure (Zsqrtd d) (Zsqrtd d) (FractionRing (Zsqrtd d)) from
-          inferInstance }
-  infer_instance
+  exact RingEquiv.isDedekindDomain e
 
 /-- If `d % 4 = 1`, then `ℤ[√d]` is not a Dedekind domain. Equivalently,
 it is not integrally closed because `(1 + √d) / 2` is integral but does not lie in

--- a/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
@@ -114,6 +114,74 @@ theorem isDedekindDomain_zsqrtd_of_mod_four_ne_one
           inferInstance }
   infer_instance
 
+/-- If `d % 4 = 1`, then `ℤ[√d]` is not a Dedekind domain. Equivalently,
+it is not integrally closed because `(1 + √d) / 2` is integral but does not lie in
+`ℤ[√d]`. -/
+theorem not_isDedekindDomain_zsqrtd_of_mod_four_eq_one
+    (d : ℤ) [QuadFieldParam d]
+    (hd4 : d % 4 = 1) :
+    ¬ IsDedekindDomain (Zsqrtd d) := by
+  letI : Algebra (Zsqrtd d) (QuadraticNumberFields d) := (Zsqrtd.toQsqrtdHom d).toAlgebra
+  letI : FaithfulSMul (Zsqrtd d) (QuadraticNumberFields d) :=
+    (faithfulSMul_iff_algebraMap_injective (Zsqrtd d) (QuadraticNumberFields d)).mpr
+      (Zsqrtd.toQsqrtdHom_injective d)
+  have hFrac : IsFractionRing (Zsqrtd d) (QuadraticNumberFields d) := by
+    refine IsFractionRing.of_field (R := Zsqrtd d) (K := QuadraticNumberFields d) ?_
+    intro z
+    refine ⟨⟨(z.re.num : ℤ) * z.im.den, (z.im.num : ℤ) * z.re.den⟩,
+        ((z.re.den * z.im.den : ℕ) : Zsqrtd d), ?_⟩
+    refine (eq_div_iff ?_).2 ?_
+    · norm_num [QuadraticNumberFields]
+    · ext
+      · simp only [Nat.cast_mul, map_mul, map_natCast, QuadraticAlgebra.re_mul,
+          QuadraticAlgebra.re_natCast, QuadraticAlgebra.im_natCast, mul_zero, add_zero,
+          QuadraticAlgebra.im_mul, zero_mul]
+        calc
+          z.re * (↑z.re.den * ↑z.im.den) = z.re * (z.re.den : ℚ) * z.im.den := by ring
+          _ = ((z.re.num : ℤ) : ℚ) * z.im.den := by rw [Rat.mul_den_eq_num]
+          _ = (((z.re.num : ℤ) * z.im.den : ℤ) : ℚ) := by norm_num
+      · simp only [Nat.cast_mul, map_mul, map_natCast, QuadraticAlgebra.im_mul,
+          QuadraticAlgebra.re_natCast, QuadraticAlgebra.im_natCast, mul_zero, zero_mul,
+          add_zero, QuadraticAlgebra.re_mul, zero_add]
+        calc
+          z.im * (↑z.re.den * ↑z.im.den) = z.im * (z.im.den : ℚ) * z.re.den := by ring
+          _ = ((z.im.num : ℤ) : ℚ) * z.re.den := by rw [Rat.mul_den_eq_num]
+          _ = (((z.im.num : ℤ) * z.re.den : ℤ) : ℚ) := by norm_num
+  letI : IsFractionRing (Zsqrtd d) (QuadraticNumberFields d) := hFrac
+  intro hDed
+  letI : IsDedekindDomain (Zsqrtd d) := hDed
+  letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
+  have hIC : IsIntegrallyClosed (Zsqrtd d) := IsDedekindRing.toIsIntegralClosure
+  letI : IsIntegrallyClosed (Zsqrtd d) := hIC
+  rcases exists_k_of_mod_four_eq_one (d := d) hd4 with ⟨k, hk⟩
+  subst hk
+  let x : QuadraticNumberFields (1 + 4 * k) := halfInt (1 + 4 * k) 1 1
+  have hx_def :
+      x = _root_.ZOnePlusSqrtOverTwo.toQsqrtdFun k (⟨0, 1⟩ : _root_.ZOnePlusSqrtOverTwo k) := by
+    ext <;> simp [x, halfInt, _root_.ZOnePlusSqrtOverTwo.toQsqrtdFun]
+  have hx_integral_Z : IsIntegral ℤ x := by
+    rw [hx_def]
+    simpa [QuadraticNumberFields] using
+      isIntegral_toQsqrtd_of_zOnePlusSqrtOverTwo k (z := (⟨0, 1⟩ : _root_.ZOnePlusSqrtOverTwo k))
+  have hx_integral : IsIntegral (Zsqrtd (1 + 4 * k)) x := hx_integral_Z.tower_top
+  rcases (isIntegrallyClosed_iff (QuadraticNumberFields (1 + 4 * k))).mp hIC hx_integral with
+    ⟨z, hz⟩
+  have h_even : 2 ∣ (1 : ℤ) ∧ 2 ∣ (1 : ℤ) :=
+    (Zsqrtd.halfInt_mem_range_toQsqrtdHom_iff_even_even (1 + 4 * k) 1 1).mp
+      ⟨z, by
+        simpa [x, halfInt, RingHom.toAlgebra, QuadraticNumberFields] using hz⟩
+  omega
+
+/-- For a valid quadratic parameter `d`, `ℤ[√d]` is Dedekind exactly in the
+`d % 4 ≠ 1` branch, i.e. precisely when it is the full ring of integers. -/
+theorem isDedekindDomain_zsqrtd_iff_mod_four_ne_one
+    (d : ℤ) [QuadFieldParam d] :
+    IsDedekindDomain (Zsqrtd d) ↔ d % 4 ≠ 1 := by
+  constructor
+  · intro hDed hd4
+    exact not_isDedekindDomain_zsqrtd_of_mod_four_eq_one d hd4 hDed
+  · exact isDedekindDomain_zsqrtd_of_mod_four_ne_one d
+
 instance instIsDedekindDomain_zsqrtd_of_mod_four_ne_one
     (d : ℤ) [QuadFieldParam d] [Fact (d % 4 ≠ 1)] :
     IsDedekindDomain (Zsqrtd d) :=

--- a/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
@@ -3,18 +3,24 @@ Copyright (c) 2026 Frankie Wang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frankie Wang
 -/
+import QuadraticNumberFields.RingOfIntegers.Classification
+import QuadraticNumberFields.RingOfIntegers.Zsqrtd
 import Mathlib.NumberTheory.Zsqrtd.Basic
+import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
+import Mathlib.RingTheory.Noetherian.Basic
 
 /-!
 # Additional Instances for mathlib `Zsqrtd`
 
 This module adds generic algebraic instances for mathlib's `_root_.Zsqrtd d`
-under the hypothesis `d < 0`.
+under useful arithmetic hypotheses.
 
 ## Main Definitions
 
 * `Zsqrtd.instNoZeroDivisors`: `NoZeroDivisors (Zsqrtd d)` for `d < 0`.
 * `Zsqrtd.instIsDomain`: `IsDomain (Zsqrtd d)` for `d < 0`.
+* `Zsqrtd.instIsDedekindDomainOfModFourNeOne`: `IsDedekindDomain (Zsqrtd d)`
+  for valid quadratic parameters with `d % 4 ≠ 1`.
 
 ## Main Theorems
 
@@ -36,5 +42,54 @@ instance instNoZeroDivisors {d : ℤ} [Fact (d < 0)] : NoZeroDivisors (Zsqrtd d)
 
 instance instIsDomain {d : ℤ} [Fact (d < 0)] : IsDomain (Zsqrtd d) :=
   NoZeroDivisors.to_isDomain (Zsqrtd d)
+
+theorem isDedekindDomain_of_mod_four_ne_one
+    (d : ℤ) [QuadFieldParam d]
+    (hd4 : d % 4 ≠ 1) :
+    IsDedekindDomain (Zsqrtd d) := by
+  let e := QuadraticNumberFields.RingOfIntegers.Zsqrtd.equivMathlib d
+  letI : IsDedekindDomain (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    QuadraticNumberFields.RingOfIntegers.isDedekindDomain_zsqrtd_of_mod_four_ne_one d hd4
+  letI : Module
+      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
+      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) := Semiring.toModule
+  letI : IsNoetherianRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    show
+      IsNoetherian
+        (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
+        (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) from
+      IsDedekindRing.toIsNoetherian
+  letI : IsDomain (Zsqrtd d) := e.toMulEquiv.isDomain_iff.mp inferInstance
+  letI : IsNoetherianRing (Zsqrtd d) :=
+    isNoetherianRing_of_ringEquiv (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) e
+  letI : IsIntegrallyClosed (Zsqrtd d) := IsIntegrallyClosed.of_equiv e
+  letI : Ring.DimensionLEOne (Zsqrtd d) :=
+    { maximalOfPrime := by
+        intro p hp0 hp
+        have hcomapPrime : (Ideal.comap e p).IsPrime := Ideal.comap_isPrime e p
+        have hcomapNeBot : Ideal.comap e p ≠ ⊥ := by
+          intro hbot
+          have hmap := Ideal.map_comap_eq_self_of_equiv e p
+          rw [hbot, Ideal.map_bot] at hmap
+          exact hp0 hmap.symm
+        have hcomapMax : (Ideal.comap e p).IsMaximal :=
+          Ring.DimensionLEOne.maximalOfPrime hcomapNeBot hcomapPrime
+        letI : (Ideal.comap e p).IsMaximal := hcomapMax
+        have hmapMax : (Ideal.map e (Ideal.comap e p)).IsMaximal :=
+          Ideal.map_isMaximal_of_equiv e
+        simpa [Ideal.map_comap_eq_self_of_equiv] using hmapMax }
+  letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
+  letI : IsDedekindRing (Zsqrtd d) :=
+    { toIsNoetherian := show IsNoetherian (Zsqrtd d) (Zsqrtd d) from inferInstance
+      toDimensionLEOne := inferInstance
+      toIsIntegralClosure :=
+        show IsIntegralClosure (Zsqrtd d) (Zsqrtd d) (FractionRing (Zsqrtd d)) from
+          inferInstance }
+  infer_instance
+
+instance instIsDedekindDomainOfModFourNeOne
+    (d : ℤ) [QuadFieldParam d] [Fact (d % 4 ≠ 1)] :
+    IsDedekindDomain (Zsqrtd d) :=
+  isDedekindDomain_of_mod_four_ne_one d Fact.out
 
 end Zsqrtd

--- a/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
@@ -21,6 +21,8 @@ under useful arithmetic hypotheses.
 * `Zsqrtd.instIsDomain`: `IsDomain (Zsqrtd d)` for `d < 0`.
 * `Zsqrtd.instIsDedekindDomainOfModFourNeOne`: `IsDedekindDomain (Zsqrtd d)`
   for valid quadratic parameters with `d % 4 ≠ 1`.
+* `Zsqrtd.not_isDedekindDomain_of_mod_four_eq_one`: `ℤ√d` is not Dedekind when
+  `d % 4 = 1`.
 
 ## Main Theorems
 
@@ -91,5 +93,68 @@ instance instIsDedekindDomainOfModFourNeOne
     (d : ℤ) [QuadFieldParam d] [Fact (d % 4 ≠ 1)] :
     IsDedekindDomain (Zsqrtd d) :=
   isDedekindDomain_of_mod_four_ne_one d Fact.out
+
+theorem not_isDedekindDomain_of_mod_four_eq_one
+    (d : ℤ) [QuadFieldParam d]
+    (hd4 : d % 4 = 1) :
+    ¬ IsDedekindDomain (Zsqrtd d) := by
+  intro hDed
+  let e := QuadraticNumberFields.RingOfIntegers.Zsqrtd.equivMathlib d
+  letI : IsDedekindDomain (Zsqrtd d) := hDed
+  letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
+  letI : IsNoetherianRing (Zsqrtd d) :=
+    show IsNoetherian (Zsqrtd d) (Zsqrtd d) from IsDedekindRing.toIsNoetherian
+  letI : IsDomain (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    e.toMulEquiv.isDomain_iff.mpr inferInstance
+  letI : IsNoetherianRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    isNoetherianRing_of_ringEquiv (Zsqrtd d) e.symm
+  letI : IsIntegrallyClosed (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    IsIntegrallyClosed.of_equiv e.symm
+  letI : Ring.DimensionLEOne (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    { maximalOfPrime := by
+        intro p hp0 hp
+        have hmapPrime : (Ideal.map e p).IsPrime := Ideal.map_isPrime_of_equiv e
+        have hcomapMap : Ideal.comap e (Ideal.map e p) = p := by
+          rw [Ideal.comap_map_of_surjective e e.surjective p,
+            Ideal.comap_bot_of_injective e e.injective, sup_bot_eq]
+        have hmapNeBot : Ideal.map e p ≠ ⊥ := by
+          intro hbot
+          rw [hbot, Ideal.comap_bot_of_injective e e.injective] at hcomapMap
+          exact hp0 hcomapMap.symm
+        have hmapMax : (Ideal.map e p).IsMaximal :=
+          Ring.DimensionLEOne.maximalOfPrime hmapNeBot hmapPrime
+        letI : (Ideal.map e p).IsMaximal := hmapMax
+        have hcomapMax : (Ideal.comap e (Ideal.map e p)).IsMaximal :=
+          Ideal.comap_isMaximal_of_equiv e
+        simpa [hcomapMap] using hcomapMax }
+  letI : Module
+      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
+      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) := Semiring.toModule
+  letI : IsDedekindRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    { toIsNoetherian :=
+        show IsNoetherian
+          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
+          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) from inferInstance
+      toDimensionLEOne := inferInstance
+      toIsIntegralClosure :=
+        show IsIntegralClosure
+          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
+          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
+          (FractionRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)) from
+            inferInstance }
+  have hDedQA : IsDedekindDomain (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) := inferInstance
+  exact
+    ((QuadraticNumberFields.RingOfIntegers.isDedekindDomain_zsqrtd_iff_mod_four_ne_one d).mp
+      hDedQA) hd4
+
+/-- For a valid quadratic parameter `d`, mathlib's `ℤ√d` is Dedekind exactly in
+the `d % 4 ≠ 1` branch. -/
+theorem isDedekindDomain_iff_mod_four_ne_one
+    (d : ℤ) [QuadFieldParam d] :
+    IsDedekindDomain (Zsqrtd d) ↔ d % 4 ≠ 1 := by
+  constructor
+  · intro hDed hd4
+    exact not_isDedekindDomain_of_mod_four_eq_one d hd4 hDed
+  · exact isDedekindDomain_of_mod_four_ne_one d
 
 end Zsqrtd

--- a/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/ZsqrtdMathlibInstances.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frankie Wang
 -/
 import QuadraticNumberFields.RingOfIntegers.Classification
+import QuadraticNumberFields.RingEquiv
 import QuadraticNumberFields.RingOfIntegers.Zsqrtd
 import Mathlib.NumberTheory.Zsqrtd.Basic
 import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
@@ -52,42 +53,7 @@ theorem isDedekindDomain_of_mod_four_ne_one
   let e := QuadraticNumberFields.RingOfIntegers.Zsqrtd.equivMathlib d
   letI : IsDedekindDomain (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
     QuadraticNumberFields.RingOfIntegers.isDedekindDomain_zsqrtd_of_mod_four_ne_one d hd4
-  letI : Module
-      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
-      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) := Semiring.toModule
-  letI : IsNoetherianRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
-    show
-      IsNoetherian
-        (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
-        (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) from
-      IsDedekindRing.toIsNoetherian
-  letI : IsDomain (Zsqrtd d) := e.toMulEquiv.isDomain_iff.mp inferInstance
-  letI : IsNoetherianRing (Zsqrtd d) :=
-    isNoetherianRing_of_ringEquiv (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) e
-  letI : IsIntegrallyClosed (Zsqrtd d) := IsIntegrallyClosed.of_equiv e
-  letI : Ring.DimensionLEOne (Zsqrtd d) :=
-    { maximalOfPrime := by
-        intro p hp0 hp
-        have hcomapPrime : (Ideal.comap e p).IsPrime := Ideal.comap_isPrime e p
-        have hcomapNeBot : Ideal.comap e p ≠ ⊥ := by
-          intro hbot
-          have hmap := Ideal.map_comap_eq_self_of_equiv e p
-          rw [hbot, Ideal.map_bot] at hmap
-          exact hp0 hmap.symm
-        have hcomapMax : (Ideal.comap e p).IsMaximal :=
-          Ring.DimensionLEOne.maximalOfPrime hcomapNeBot hcomapPrime
-        letI : (Ideal.comap e p).IsMaximal := hcomapMax
-        have hmapMax : (Ideal.map e (Ideal.comap e p)).IsMaximal :=
-          Ideal.map_isMaximal_of_equiv e
-        simpa [Ideal.map_comap_eq_self_of_equiv] using hmapMax }
-  letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
-  letI : IsDedekindRing (Zsqrtd d) :=
-    { toIsNoetherian := show IsNoetherian (Zsqrtd d) (Zsqrtd d) from inferInstance
-      toDimensionLEOne := inferInstance
-      toIsIntegralClosure :=
-        show IsIntegralClosure (Zsqrtd d) (Zsqrtd d) (FractionRing (Zsqrtd d)) from
-          inferInstance }
-  infer_instance
+  exact RingEquiv.isDedekindDomain e
 
 instance instIsDedekindDomainOfModFourNeOne
     (d : ℤ) [QuadFieldParam d] [Fact (d % 4 ≠ 1)] :
@@ -99,50 +65,10 @@ theorem not_isDedekindDomain_of_mod_four_eq_one
     (hd4 : d % 4 = 1) :
     ¬ IsDedekindDomain (Zsqrtd d) := by
   intro hDed
-  let e := QuadraticNumberFields.RingOfIntegers.Zsqrtd.equivMathlib d
   letI : IsDedekindDomain (Zsqrtd d) := hDed
-  letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
-  letI : IsNoetherianRing (Zsqrtd d) :=
-    show IsNoetherian (Zsqrtd d) (Zsqrtd d) from IsDedekindRing.toIsNoetherian
-  letI : IsDomain (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
-    e.toMulEquiv.isDomain_iff.mpr inferInstance
-  letI : IsNoetherianRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
-    isNoetherianRing_of_ringEquiv (Zsqrtd d) e.symm
-  letI : IsIntegrallyClosed (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
-    IsIntegrallyClosed.of_equiv e.symm
-  letI : Ring.DimensionLEOne (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
-    { maximalOfPrime := by
-        intro p hp0 hp
-        have hmapPrime : (Ideal.map e p).IsPrime := Ideal.map_isPrime_of_equiv e
-        have hcomapMap : Ideal.comap e (Ideal.map e p) = p := by
-          rw [Ideal.comap_map_of_surjective e e.surjective p,
-            Ideal.comap_bot_of_injective e e.injective, sup_bot_eq]
-        have hmapNeBot : Ideal.map e p ≠ ⊥ := by
-          intro hbot
-          rw [hbot, Ideal.comap_bot_of_injective e e.injective] at hcomapMap
-          exact hp0 hcomapMap.symm
-        have hmapMax : (Ideal.map e p).IsMaximal :=
-          Ring.DimensionLEOne.maximalOfPrime hmapNeBot hmapPrime
-        letI : (Ideal.map e p).IsMaximal := hmapMax
-        have hcomapMax : (Ideal.comap e (Ideal.map e p)).IsMaximal :=
-          Ideal.comap_isMaximal_of_equiv e
-        simpa [hcomapMap] using hcomapMax }
-  letI : Module
-      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
-      (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) := Semiring.toModule
-  letI : IsDedekindRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
-    { toIsNoetherian :=
-        show IsNoetherian
-          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
-          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) from inferInstance
-      toDimensionLEOne := inferInstance
-      toIsIntegralClosure :=
-        show IsIntegralClosure
-          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
-          (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)
-          (FractionRing (QuadraticNumberFields.RingOfIntegers.Zsqrtd d)) from
-            inferInstance }
-  have hDedQA : IsDedekindDomain (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) := inferInstance
+  have hDedQA : IsDedekindDomain (QuadraticNumberFields.RingOfIntegers.Zsqrtd d) :=
+    RingEquiv.isDedekindDomain
+      (QuadraticNumberFields.RingOfIntegers.Zsqrtd.equivMathlib d).symm
   exact
     ((QuadraticNumberFields.RingOfIntegers.isDedekindDomain_zsqrtd_iff_mod_four_ne_one d).mp
       hDedQA) hd4


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
feat: Add Dedekind domain structure for `ℤ[√d]` when `d % 4 ≠ 1`

This pull request introduces a proof and an instance demonstrating that `ℤ[√d]` (represented as `Zsqrtd d`) is a Dedekind domain when the integer `d` is not congruent to 1 modulo 4.

The proof leverages the existing theorem `ringOfIntegers_equiv_zsqrtd_of_mod_four_ne_one`, which establishes a ring equivalence between `Zsqrtd d` and the full ring of integers `𝓞(Q(√d))` under the condition `d % 4 ≠ 1`. Since `𝓞(Q(√d))` is known to be a Dedekind domain, the `IsDedekindDomain` structure is transferred to `Zsqrtd d` via this equivalence.

The implementation explicitly derives the necessary properties for `Zsqrtd d` (such as being an integral domain, a Noetherian ring, integrally closed, and having Krull dimension at most one) from the corresponding properties of `𝓞(Q(√d))` using the ring isomorphism.
<!-- kody-pr-summary:end -->