### PR TITLE
sync: align with mathlib PR #36347 changes

### DIFF
--- a/Lean/QuadraticNumberFields/Basic.lean
+++ b/Lean/QuadraticNumberFields/Basic.lean
@@ -120,7 +120,8 @@ end Qsqrtd
 
 /-- A squarefree integer that is a perfect square must equal `1` or `-1`.
 This is a local version until `Squarefree.isUnit_of_isSquare` is merged into mathlib. -/
-lemma eq_one_of_squarefree_isSquare {d : ℤ} (hd : Squarefree d) (hsq : IsSquare d) : d = 1 ∨ d = -1 := by
+lemma eq_one_of_squarefree_isSquare {d : ℤ} (hd : Squarefree d) (hsq : IsSquare d) :
+    d = 1 ∨ d = -1 := by
   obtain ⟨z, rfl⟩ := hsq
   have hsqz2 : Squarefree (z ^ 2) := by simpa [pow_two] using hd
   have huz : IsUnit z := by

--- a/Lean/QuadraticNumberFields/Basic.lean
+++ b/Lean/QuadraticNumberFields/Basic.lean
@@ -46,18 +46,20 @@ open QuadraticAlgebra
 
 variable {d : ℚ}
 
-/-- The canonical embedding of ℚ into `Q(√d)`, mapping `r ↦ r + 0·√d`. -/
-abbrev embed (r : ℚ) : Qsqrtd d := algebraMap ℚ (Qsqrtd d) r
-
-/-- The left multiplication matrix of an element in `Qsqrtd d` with respect to the basis `{1, √d}`.
-This is a local version until `QuadraticAlgebra.leftMulMatrix_eq` is merged into mathlib. -/
-private theorem leftMulMatrix_eq (x : Qsqrtd d) :
-    Algebra.leftMulMatrix (QuadraticAlgebra.basis d 0) x = !![x.re, d * x.im; x.im, x.re] := by
+section CommSemiring
+variable [CommSemiring R]
+/-- The left multiplication matrix of an element in `QuadraticAlgebra R a b`
+with respect to the basis `{1, i}`.
+PR#36347 this theorem will be in QuadraticAlgebra.Defs.lean -/
+theorem leftMulMatrix_eq (x : QuadraticAlgebra R a b) :
+    Algebra.leftMulMatrix (basis a b) x = !![x.re, a * x.im; x.im, x.re + b * x.im] := by
   ext i j
   fin_cases i <;> fin_cases j
   all_goals
     rw [Algebra.leftMulMatrix_apply, LinearMap.toMatrix_apply]
     simp [QuadraticAlgebra.basis]
+
+end CommSemiring
 
 /-- The trace in `Q(√d)` is `x.re + x̄.re`. -/
 @[simp] theorem trace_eq_re_add_re_star (x : Qsqrtd d) :

--- a/Lean/QuadraticNumberFields/Basic.lean
+++ b/Lean/QuadraticNumberFields/Basic.lean
@@ -8,22 +8,26 @@ import Mathlib.Algebra.Squarefree.Basic
 import Mathlib.LinearAlgebra.Dimension.Finrank
 import Mathlib.RingTheory.Int.Basic
 import Mathlib.RingTheory.Trace.Basic
-import Init.Data.Rat.Basic
+import Mathlib.NumberTheory.NumberField.Basic
 
 /-!
 # Basic Definitions for Quadratic Number Fields
 
-This file provides the fundamental type `Qsqrtd d` representing the quadratic
-field `ℚ(√d)` for a rational parameter `d`, along with basic operations:
-trace, norm, and the canonical embedding of ℚ.
+This file defines the concept of a quadratic number field as a degree-2 extension of `ℚ`,
+builds the concrete model `ℚ(√d)` as `QuadraticAlgebra ℚ d 0`, and proves basic properties
+including norm, trace, and field/number field instances.
 
 ## Main Definitions
 
-* `IsQuadraticField K`: A predicate asserting that `K` is a quadratic extension of ℚ.
+* `IsQuadraticField K`: A predicate asserting that `K` is a quadratic extension of `ℚ`.
+  This is defined as `Algebra.IsQuadraticExtension ℚ K`.
 * `Qsqrtd d`: The quadratic algebra `QuadraticAlgebra ℚ d 0`, representing `ℚ(√d)`.
-* `Qsqrtd.trace`: The trace `Tr(x)`, defined via mathlib's `Algebra.trace`.
 * `Qsqrtd.norm`: The norm `N(x) = x · x̄ = x.re² - d · x.im²`.
-* `Qsqrtd.embed`: The canonical embedding `ℚ → Q(√d)`.
+
+## Main Results
+
+* `IsQuadraticField.instNumberField`: Any quadratic field is a number field.
+* `Qsqrtd.instIsQuadraticExtension`: `ℚ(√d)/ℚ` is a degree-2 extension.
 * `not_isSquare_ratCast_of_squarefree_ne_one`: squarefree integer parameters
   with `d ≠ 1` give genuine quadratic fields.
 -/
@@ -38,13 +42,15 @@ notation "ℚ√" d => Qsqrtd d
 
 namespace Qsqrtd
 
-/-- The trace of an element `x : Q(√d)`, defined via `Algebra.trace`. -/
-noncomputable abbrev trace (x : Qsqrtd d) : ℚ := Algebra.trace ℚ (Qsqrtd d) x
+open QuadraticAlgebra
 
-/-- `Qsqrtd.trace` is definitionally mathlib's algebra trace. -/
-theorem trace_eq_algebra_trace (x : Qsqrtd d) :
-    Qsqrtd.trace x = Algebra.trace ℚ (Qsqrtd d) x := rfl
+variable {d : ℚ}
 
+/-- The canonical embedding of ℚ into `Q(√d)`, mapping `r ↦ r + 0·√d`. -/
+abbrev embed (r : ℚ) : Qsqrtd d := algebraMap ℚ (Qsqrtd d) r
+
+/-- The left multiplication matrix of an element in `Qsqrtd d` with respect to the basis `{1, √d}`.
+This is a local version until `QuadraticAlgebra.leftMulMatrix_eq` is merged into mathlib. -/
 private theorem leftMulMatrix_eq (x : Qsqrtd d) :
     Algebra.leftMulMatrix (QuadraticAlgebra.basis d 0) x = !![x.re, d * x.im; x.im, x.re] := by
   ext i j
@@ -53,17 +59,16 @@ private theorem leftMulMatrix_eq (x : Qsqrtd d) :
     rw [Algebra.leftMulMatrix_apply, LinearMap.toMatrix_apply]
     simp [QuadraticAlgebra.basis]
 
-/-- The trace in `Q(√d)` is `x + x̄`. -/
+/-- The trace in `Q(√d)` is `x.re + x̄.re`. -/
 @[simp] theorem trace_eq_re_add_re_star (x : Qsqrtd d) :
-    Qsqrtd.trace x = x.re + (star x).re := by
-  change Algebra.trace ℚ (Qsqrtd d) x = x.re + (star x).re
+    Algebra.trace ℚ (Qsqrtd d) x = x.re + (star x).re := by
   rw [Algebra.trace_eq_matrix_trace (QuadraticAlgebra.basis d 0), leftMulMatrix_eq,
     Matrix.trace_fin_two_of]
   simp
 
 /-- In the model `Q(√d) = QuadraticAlgebra ℚ d 0`, the trace is `2 * re`. -/
-@[simp] theorem trace_eq_two_re (x : Qsqrtd d) :
-    Qsqrtd.trace x = 2 * x.re := by
+theorem trace_eq_two_re (x : Qsqrtd d) :
+    Algebra.trace ℚ (Qsqrtd d) x = 2 * x.re := by
   rw [trace_eq_re_add_re_star]
   simp
   ring
@@ -71,15 +76,8 @@ private theorem leftMulMatrix_eq (x : Qsqrtd d) :
 /-- The norm of an element `x : Q(√d)`, defined as `N(x) = x · x̄ = x.re² - d · x.im²`. -/
 abbrev norm {d : ℚ} (x : Qsqrtd d) : ℚ := QuadraticAlgebra.norm x
 
-/-- The canonical embedding of ℚ into `Q(√d)`, mapping `r ↦ r + 0·√d`. -/
-abbrev embed (r : ℚ) : Qsqrtd d := algebraMap ℚ (Qsqrtd d) r
-
-end Qsqrtd
-
-/-! ## Parameter Lemmas -/
-
 /-- `Q(√0)` is not reduced because `√0² = 0` but `√0 ≠ 0`. -/
-lemma Qsqrtd.zero_not_isReduced : ¬ IsReduced (Qsqrtd (0 : ℚ)) := by
+lemma zero_not_isReduced : ¬ IsReduced (Qsqrtd (0 : ℚ)) := by
   intro ⟨h⟩
   have hnil : IsNilpotent (⟨0, 1⟩ : Qsqrtd 0) :=
     ⟨2, by ext <;> simp [pow_succ, pow_zero, QuadraticAlgebra.mk_mul_mk]⟩
@@ -89,13 +87,13 @@ lemma Qsqrtd.zero_not_isReduced : ¬ IsReduced (Qsqrtd (0 : ℚ)) := by
   exact hne (h _ hnil)
 
 /-- `Q(√0)` is not a field (it has nilpotents). -/
-lemma Qsqrtd.zero_not_isField : ¬ IsField (Qsqrtd (0 : ℚ)) := by
+lemma zero_not_isField : ¬ IsField (Qsqrtd (0 : ℚ)) := by
   intro hF
   haveI := hF.isDomain
-  exact Qsqrtd.zero_not_isReduced (inferInstance : IsReduced (Qsqrtd (0 : ℚ)))
+  exact zero_not_isReduced (inferInstance : IsReduced (Qsqrtd (0 : ℚ)))
 
 /-- `Q(√1) ≅ ℚ × ℚ` is not a field (it has zero divisors). -/
-lemma Qsqrtd.one_not_isField : ¬ IsField (Qsqrtd (1 : ℚ)) := by
+lemma one_not_isField : ¬ IsField (Qsqrtd (1 : ℚ)) := by
   intro hF
   haveI := hF.isDomain
   have hprod : (⟨1, 1⟩ : Qsqrtd 1) * ⟨1, -1⟩ = 0 := by
@@ -108,24 +106,33 @@ lemma Qsqrtd.one_not_isField : ¬ IsField (Qsqrtd (1 : ℚ)) := by
     exact one_ne_zero (congr_arg QuadraticAlgebra.re h)
   rcases mul_eq_zero.mp hprod with h | h <;> contradiction
 
-/-- A squarefree integer that is a perfect square must equal `1`. -/
-lemma eq_one_of_squarefree_isSquare {d : ℤ} (hd : Squarefree d) (hsq : IsSquare d) : d = 1 := by
-  rcases hsq with ⟨z, hz⟩
-  by_cases huz : IsUnit z
-  · rcases Int.isUnit_iff.mp huz with hz1 | hz1
-    · simpa [hz1] using hz
-    · simpa [hz1] using hz
-  · have hsqz2 : Squarefree (z ^ 2) := by
-      simpa [hz, pow_two] using hd
+/-- Bridge: `¬ IsSquare d` implies the technical `Fact` needed by
+`QuadraticAlgebra.instField`. -/
+instance instFact_of_not_isSquare (d : ℚ) [Fact (¬ IsSquare d)] :
+    Fact (∀ r : ℚ, r ^ 2 ≠ d + 0 * r) :=
+  ⟨by intro r hr; exact (Fact.out : ¬ IsSquare d) ⟨r, by nlinarith [hr]⟩⟩
+
+end Qsqrtd
+
+/-! ## Integer Parameter Lemmas -/
+
+/-- A squarefree integer that is a perfect square must equal `1` or `-1`.
+This is a local version until `Squarefree.isUnit_of_isSquare` is merged into mathlib. -/
+lemma eq_one_of_squarefree_isSquare {d : ℤ} (hd : Squarefree d) (hsq : IsSquare d) : d = 1 ∨ d = -1 := by
+  obtain ⟨z, rfl⟩ := hsq
+  have hsqz2 : Squarefree (z ^ 2) := by simpa [pow_two] using hd
+  have huz : IsUnit z := by
+    by_contra hne
     have h01 : (2 : ℕ) = 0 ∨ (2 : ℕ) = 1 :=
-      Squarefree.eq_zero_or_one_of_pow_of_not_isUnit (x := z) (n := 2) hsqz2 huz
+      Squarefree.eq_zero_or_one_of_pow_of_not_isUnit (x := z) (n := 2) hsqz2 hne
     norm_num at h01
+  rcases Int.isUnit_iff.mp huz with rfl | rfl <;> simp
 
 /-- For a squarefree integer `d ≠ 1`, `d` is not a perfect square in `ℤ`. -/
 lemma not_isSquare_int_of_squarefree_ne_one {d : ℤ}
     (hd : Squarefree d) (h1 : d ≠ 1) : ¬ IsSquare d := by
-  intro hdSq
-  exact h1 (eq_one_of_squarefree_isSquare hd hdSq)
+  intro hsq
+  rcases eq_one_of_squarefree_isSquare hd hsq with rfl | rfl <;> simp_all
 
 /-- For a squarefree integer `d ≠ 1`, `(d : ℚ)` is not a perfect square in `ℚ`. -/
 lemma not_isSquare_ratCast_of_squarefree_ne_one {d : ℤ}

--- a/Lean/QuadraticNumberFields/Basic.lean
+++ b/Lean/QuadraticNumberFields/Basic.lean
@@ -53,6 +53,8 @@ with respect to the basis `{1, i}`.
 PR#36347 this theorem will be in QuadraticAlgebra.Defs.lean -/
 theorem leftMulMatrix_eq (x : QuadraticAlgebra R a b) :
     Algebra.leftMulMatrix (basis a b) x = !![x.re, a * x.im; x.im, x.re + b * x.im] := by
+  -- In the basis `{1, i}`, multiplication by `x = x.re + x.im * i`
+  -- sends `1` and `i` to the two displayed columns.
   ext i j
   fin_cases i <;> fin_cases j
   all_goals
@@ -64,6 +66,8 @@ end CommSemiring
 /-- The trace in `Q(√d)` is `x.re + x̄.re`. -/
 @[simp] theorem trace_eq_re_add_re_star (x : Qsqrtd d) :
     Algebra.trace ℚ (Qsqrtd d) x = x.re + (star x).re := by
+  -- The trace is the matrix trace of left multiplication, so we just
+  -- read off the two diagonal entries from the explicit `2 × 2` matrix.
   rw [Algebra.trace_eq_matrix_trace (QuadraticAlgebra.basis d 0), leftMulMatrix_eq,
     Matrix.trace_fin_two_of]
   simp
@@ -71,6 +75,7 @@ end CommSemiring
 /-- In the model `Q(√d) = QuadraticAlgebra ℚ d 0`, the trace is `2 * re`. -/
 theorem trace_eq_two_re (x : Qsqrtd d) :
     Algebra.trace ℚ (Qsqrtd d) x = 2 * x.re := by
+  -- In `QuadraticAlgebra ℚ d 0`, conjugation fixes the real part.
   rw [trace_eq_re_add_re_star]
   simp
   ring
@@ -81,6 +86,8 @@ abbrev norm {d : ℚ} (x : Qsqrtd d) : ℚ := QuadraticAlgebra.norm x
 /-- `Q(√0)` is not reduced because `√0² = 0` but `√0 ≠ 0`. -/
 lemma zero_not_isReduced : ¬ IsReduced (Qsqrtd (0 : ℚ)) := by
   intro ⟨h⟩
+  -- When `d = 0`, the element `ε = ⟨0, 1⟩` satisfies `ε² = 0`,
+  -- so it is a nonzero nilpotent.
   have hnil : IsNilpotent (⟨0, 1⟩ : Qsqrtd 0) :=
     ⟨2, by ext <;> simp [pow_succ, pow_zero, QuadraticAlgebra.mk_mul_mk]⟩
   have hne : (⟨0, 1⟩ : Qsqrtd 0) ≠ 0 := by
@@ -98,6 +105,8 @@ lemma zero_not_isField : ¬ IsField (Qsqrtd (0 : ℚ)) := by
 lemma one_not_isField : ¬ IsField (Qsqrtd (1 : ℚ)) := by
   intro hF
   haveI := hF.isDomain
+  -- For `d = 1`, the standard factorization
+  -- `(1 + √1) (1 - √1) = 1 - (√1)^2 = 0` gives zero divisors.
   have hprod : (⟨1, 1⟩ : Qsqrtd 1) * ⟨1, -1⟩ = 0 := by
     ext <;> simp
   have hne : (⟨1, 1⟩ : Qsqrtd 1) ≠ 0 := by
@@ -112,6 +121,8 @@ lemma one_not_isField : ¬ IsField (Qsqrtd (1 : ℚ)) := by
 `QuadraticAlgebra.instField`. -/
 instance instFact_of_not_isSquare (d : ℚ) [Fact (¬ IsSquare d)] :
     Fact (∀ r : ℚ, r ^ 2 ≠ d + 0 * r) :=
+  -- For `b = 0`, the field criterion for `QuadraticAlgebra ℚ d b`
+  -- reduces to saying that `X^2 - d` has no rational root.
   ⟨by intro r hr; exact (Fact.out : ¬ IsSquare d) ⟨r, by nlinarith [hr]⟩⟩
 
 end Qsqrtd

--- a/Lean/QuadraticNumberFields/Instances.lean
+++ b/Lean/QuadraticNumberFields/Instances.lean
@@ -7,52 +7,54 @@ import QuadraticNumberFields.Basic
 import Mathlib.NumberTheory.NumberField.Basic
 
 /-!
-# Field and Number Field Instances for `Qsqrtd`
+# Field and Number Field Instances for Quadratic Algebras over ℚ
 
-This file equips `Qsqrtd d` (i.e., `QuadraticAlgebra ℚ d 0`) with `Field` and
-`NumberField` typeclass instances, gated by `[Fact (¬ IsSquare d)]`.
+This file provides `NumberField` instances for quadratic extensions of `ℚ`.
 
 ## Main Instances
 
-* `Field (Qsqrtd d)`: `Q(√d)` is a field when `d` is not a perfect square.
-* `NumberField (Qsqrtd d)`: `Q(√d)` is a number field.
-* `Algebra.IsQuadraticExtension ℚ (Qsqrtd d)`: `Q(√d)/ℚ` is a degree-2 extension.
+* `IsQuadraticField.instNumberField`: Any quadratic field is a number field.
+* `QuadraticAlgebra.instIsQuadraticExtension`: Any `QuadraticAlgebra ℚ a b` that is a field
+  is a quadratic extension of `ℚ`.
 
 ## Implementation Note
 
-`Field (QuadraticAlgebra R a b)` requires `Fact (∀ r, r^2 ≠ a + b*r)`.
-For `b = 0` this simplifies to `¬ IsSquare d`. We provide a bridge instance
-`Qsqrtd.instFact_of_not_isSquare` so that `[Fact (¬ IsSquare d)]` suffices.
+The `Module ℚ` instance from the `Field` algebra structure on `QuadraticAlgebra ℚ a b`
+coincides with the `QuadraticAlgebra` module structure. This resolves the diamond between
+the two `Algebra ℚ` instances (`DivisionRing.toRatAlgebra` vs `QuadraticAlgebra.instAlgebra`).
 -/
 
-namespace Qsqrtd
+/-! ## NumberField Instance -/
 
-/-- Bridge: `¬ IsSquare d` implies the technical `Fact` needed by
-`QuadraticAlgebra.instField`. -/
-instance instFact_of_not_isSquare (d : ℚ) [Fact (¬ IsSquare d)] :
-    Fact (∀ r : ℚ, r ^ 2 ≠ d + 0 * r) :=
-  ⟨by intro r hr; exact (Fact.out : ¬ IsSquare d) ⟨r, by nlinarith [hr]⟩⟩
+/-- A quadratic field is a number field: it has characteristic zero
+and is finite-dimensional over `ℚ`. -/
+instance IsQuadraticField.instNumberField (K : Type*) [Field K] [Algebra ℚ K]
+    [IsQuadraticField K] : NumberField K where
+  to_charZero := charZero_of_injective_algebraMap (algebraMap ℚ K).injective
+  to_finiteDimensional := by
+    haveI : CharZero K := charZero_of_injective_algebraMap (algebraMap ℚ K).injective
+    convert FiniteDimensional.of_finrank_pos (K := ℚ) (V := K) (by
+      rw [Algebra.IsQuadraticExtension.finrank_eq_two (R := ℚ) (S := K)]; omega) using 1
+    congr 1
+    exact Subsingleton.elim _ _
 
-/-- The `Module ℚ` instance from the `Field` algebra structure on `Qsqrtd d` coincides
-with the `QuadraticAlgebra` module structure. This resolves the diamond. -/
-private theorem module_eq (d : ℚ) [Fact (¬ IsSquare d)] :
-    (Algebra.toModule : Module ℚ (Qsqrtd d)) =
+/-! ## Quadratic Extension Instances -/
+
+/-- The `Module ℚ` instance from the `Field` algebra structure on `QuadraticAlgebra ℚ a b`
+coincides with the `QuadraticAlgebra` module structure. This resolves the diamond between
+the two `Algebra ℚ` instances (`DivisionRing.toRatAlgebra` vs `QuadraticAlgebra.instAlgebra`). -/
+private theorem QuadraticAlgebra.module_eq (a b : ℚ) [Fact (∀ r : ℚ, r ^ 2 ≠ a + b * r)] :
+    (Algebra.toModule : Module ℚ (QuadraticAlgebra ℚ a b)) =
       QuadraticAlgebra.instModule := by
   refine Module.ext' _ _ ?_
   intro r x
   simpa [Algebra.smul_def, QuadraticAlgebra.algebraMap_eq] using
-    (QuadraticAlgebra.C_mul_eq_smul (R := ℚ) (a := d) (b := (0 : ℚ)) r x)
+    (QuadraticAlgebra.C_mul_eq_smul (R := ℚ) (a := a) (b := b) r x)
 
-/-- `Q(√d)` is a number field: characteristic zero and finite-dimensional over ℚ. -/
-instance instNumberField (d : ℚ) [Fact (¬ IsSquare d)] : NumberField (Qsqrtd d) where
-  to_charZero := by infer_instance
-  to_finiteDimensional := by
-    letI : Module ℚ (Qsqrtd d) := QuadraticAlgebra.instModule
-    exact module_eq d ▸ (inferInstance : Module.Finite ℚ (Qsqrtd d))
-
-/-- `Q(√d)/ℚ` is a quadratic extension: free of rank 2 over `ℚ`. -/
-instance instIsQuadraticExtension (d : ℚ) [Fact (¬ IsSquare d)] :
-    Algebra.IsQuadraticExtension ℚ (Qsqrtd d) where
-  finrank_eq_two' := module_eq d ▸ QuadraticAlgebra.finrank_eq_two d 0
-
-end Qsqrtd
+/-- Any `QuadraticAlgebra ℚ a b` that is a field is automatically a quadratic extension
+of `ℚ`, i.e., a degree-2 extension. Combined with `IsQuadraticField.instNumberField`,
+this gives `NumberField (QuadraticAlgebra ℚ a b)` for free. -/
+instance QuadraticAlgebra.instIsQuadraticExtension (a b : ℚ)
+    [Fact (∀ r : ℚ, r ^ 2 ≠ a + b * r)] :
+    Algebra.IsQuadraticExtension ℚ (QuadraticAlgebra ℚ a b) where
+  finrank_eq_two' := QuadraticAlgebra.module_eq a b ▸ QuadraticAlgebra.finrank_eq_two a b

--- a/Lean/QuadraticNumberFields/Instances.lean
+++ b/Lean/QuadraticNumberFields/Instances.lean
@@ -33,6 +33,8 @@ instance IsQuadraticField.instNumberField (K : Type*) [Field K] [Algebra ℚ K]
   to_charZero := charZero_of_injective_algebraMap (algebraMap ℚ K).injective
   to_finiteDimensional := by
     haveI : CharZero K := charZero_of_injective_algebraMap (algebraMap ℚ K).injective
+    -- A quadratic extension has `ℚ`-dimension exactly `2`, hence in particular
+    -- positive finite dimension.
     convert FiniteDimensional.of_finrank_pos (K := ℚ) (V := K) (by
       rw [Algebra.IsQuadraticExtension.finrank_eq_two (R := ℚ) (S := K)]; omega) using 1
     congr 1
@@ -46,6 +48,8 @@ the two `Algebra ℚ` instances (`DivisionRing.toRatAlgebra` vs `QuadraticAlgebr
 private theorem QuadraticAlgebra.module_eq (a b : ℚ) [Fact (∀ r : ℚ, r ^ 2 ≠ a + b * r)] :
     (Algebra.toModule : Module ℚ (QuadraticAlgebra ℚ a b)) =
       QuadraticAlgebra.instModule := by
+  -- Both module structures act by scalar multiplication through the same copy
+  -- of `ℚ` inside the quadratic algebra.
   refine Module.ext' _ _ ?_
   intro r x
   simpa [Algebra.smul_def, QuadraticAlgebra.algebraMap_eq] using
@@ -57,4 +61,6 @@ this gives `NumberField (QuadraticAlgebra ℚ a b)` for free. -/
 instance QuadraticAlgebra.instIsQuadraticExtension (a b : ℚ)
     [Fact (∀ r : ℚ, r ^ 2 ≠ a + b * r)] :
     Algebra.IsQuadraticExtension ℚ (QuadraticAlgebra ℚ a b) where
+  -- After identifying the module structures, the standard quadratic-algebra basis
+  -- immediately gives dimension `2`.
   finrank_eq_two' := QuadraticAlgebra.module_eq a b ▸ QuadraticAlgebra.finrank_eq_two a b

--- a/Lean/QuadraticNumberFields/Parameters.lean
+++ b/Lean/QuadraticNumberFields/Parameters.lean
@@ -50,6 +50,8 @@ def Qsqrtd.rescale (d : ℚ) (a : ℚ) (ha : a ≠ 0) :
   have h1d : (1 : Qsqrtd d) = ⟨1, 0⟩ := by ext <;> rfl
   have h1a : (1 : Qsqrtd (a ^ 2 * d)) = ⟨1, 0⟩ := by
     ext <;> rfl
+  -- This is the change of generator
+  -- `√d ↦ a⁻¹ * √(a² d)`, with the real part unchanged.
   exact AlgEquiv.ofLinearEquiv
     { toFun := fun x => ⟨x.re, x.im * a⁻¹⟩
       invFun := fun y => ⟨y.re, y.im * a⟩
@@ -71,6 +73,8 @@ theorem Qsqrtd_iso_int_param (d : ℚ) :
     exact ⟨d.num, d.den, Int.ofNat_ne_zero.mpr hd, (Rat.num_div_den d).symm⟩
   use m * n
   have ha : (n : ℚ) ≠ 0 := by exact_mod_cast hn0
+  -- Clearing the denominator replaces `d = m / n` by `n² d = mn`,
+  -- so after rescaling the parameter becomes an integer.
   have hrescale : Qsqrtd d ≃ₐ[ℚ] Qsqrtd (n ^ 2 * d) := Qsqrtd.rescale d n ha
   have heq : (n : ℚ) ^ 2 * d = m * n := by
     rw [hd]
@@ -92,6 +96,8 @@ theorem Qsqrtd_iso_squarefree_int_param {d : ℤ} (hd : d ≠ 0) :
   · rw [← Int.squarefree_natAbs]
     rwa [Int.natAbs_mul, Int.natAbs_sign_of_ne_zero hd, Int.natAbs_natCast, one_mul]
   · have hbQ : (b : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hb
+    -- Write `|d| = b² a` with `a` squarefree, then absorb the square factor `b²`
+    -- using the rescaling isomorphism.
     have hrescale := Qsqrtd.rescale (↑d) (↑b)⁻¹ (inv_ne_zero hbQ)
     have hd_int : d = d.sign * (↑b ^ 2 * ↑a) := by
       conv_lhs => rw [(Int.sign_mul_natAbs d).symm]
@@ -127,6 +133,9 @@ lemma nat_eq_one_of_squarefree_intcast_of_isSquare (m : ℕ)
 /-- If `d₁/d₂` is a rational square and `d₂` is squarefree, then `d₂ ∣ d₁`. -/
 lemma int_dvd_of_ratio_square (d₁ d₂ : ℤ) (hd₂ : d₂ ≠ 0)
     (hsq_d₂ : Squarefree d₂) (hr : IsSquare ((d₁ : ℚ) / (d₂ : ℚ))) : d₂ ∣ d₁ := by
+  -- A rational square has square numerator and denominator.
+  -- Since the denominator divides the squarefree integer `d₂`,
+  -- it must itself be `1`.
   have hsq_den_nat : IsSquare (((d₁ : ℚ) / (d₂ : ℚ)).den) := (Rat.isSquare_iff.mp hr).2
   have hsq_den_int : IsSquare ((((d₁ : ℚ) / (d₂ : ℚ)).den : ℤ)) := by
     rcases hsq_den_nat with ⟨n, hn⟩
@@ -171,6 +180,8 @@ lemma squarefree_eq_of_rat_sq_mul {d₁ d₂ : ℤ}
         field_simp [hs0]
   have hd21 : d₂ ∣ d₁ := int_dvd_of_ratio_square d₁ d₂ hd₂0 hd₂ hratio
   have hd12 : d₁ ∣ d₂ := int_dvd_of_ratio_square d₂ d₁ hd₁0 hd₁ hratio'
+  -- Mutual divisibility makes `d₁` and `d₂` associated, so over `ℤ`
+  -- they differ by at most a sign.
   have hassoc : Associated d₁ d₂ := associated_of_dvd_dvd hd12 hd21
   rcases (Int.associated_iff.mp hassoc) with hEq | hNeg
   · exact hEq
@@ -178,6 +189,8 @@ lemma squarefree_eq_of_rat_sq_mul {d₁ d₂ : ℤ}
       rw [hNeg]
       push_cast
       field_simp [hd₂Q]
+    -- The negative sign is impossible because it would force `-1`
+    -- to be a rational square.
     exfalso
     exact not_isSquare_neg_one_rat (by rwa [this] at hratio)
 
@@ -216,15 +229,20 @@ theorem Qsqrtd.param_unique (φ : Qsqrtd (d₁ : ℚ) ≃ₐ[ℚ] Qsqrtd (d₂ :
     have := congr_arg QuadraticAlgebra.im hφ_sq
     rw [hφ_eta, QuadraticAlgebra.mk_mul_mk] at this; simp at this; linarith
   have hb : b ≠ 0 := by
+    -- If `b = 0`, then the equation for the real part says `d₁ = a²`,
+    -- contradicting that the squarefree integer parameter `d₁` is non-square.
     intro hb0; simp [hb0] at hre
     have : IsSquare ((d₁ : ℤ) : ℚ) := ⟨a, by nlinarith⟩
     exact not_isSquare_int_of_squarefree_ne_one hsf₁ h1₁
       (Rat.isSquare_intCast_iff.mp this)
   have ha : a = 0 := by
+    -- Since `b ≠ 0`, the vanishing of the imaginary part forces `a = 0`.
     rcases mul_eq_zero.mp him with h | h
     · exact (mul_eq_zero.mp h).resolve_left (by norm_num)
     · exact absurd h hb
   have hr : (d₁ : ℚ) = d₂ * b ^ 2 := by nlinarith [hre, ha]
+  -- So the two parameters differ by a rational square factor, and squarefreeness
+  -- removes that ambiguity.
   exact squarefree_eq_of_rat_sq_mul hsf₁ hsf₂ hr
 
 end ParamLevel

--- a/Lean/QuadraticNumberFields/Parameters.lean
+++ b/Lean/QuadraticNumberFields/Parameters.lean
@@ -191,6 +191,8 @@ variable (d₁ d₂ : ℤ)
     `ℚ(√d₁) ≃ₐ[ℚ] ℚ(√d₂)` with both squarefree and `≠ 1` implies `d₁ = d₂`. -/
 theorem Qsqrtd.param_unique (φ : Qsqrtd (d₁ : ℚ) ≃ₐ[ℚ] Qsqrtd (d₂ : ℚ))
     (hsf₁ : Squarefree d₁) (h1₁ : d₁ ≠ 1) (hsf₂ : Squarefree d₂) : d₁ = d₂ := by
+  -- The idea is to write `φ ⟨0, 1⟩ = ⟨a, b⟩`
+  -- ⟨0, 1⟩² = ⟨d₁, 0⟩ implies `a² + d₂ b² = d₁` and `2ab = 0`.
   set a := (φ ⟨0, 1⟩).re
   set b := (φ ⟨0, 1⟩).im
   have hε_sq : (⟨0, 1⟩ : Qsqrtd (d₁ : ℚ)) * ⟨0, 1⟩ = ⟨(d₁ : ℚ), 0⟩ := by

--- a/Lean/QuadraticNumberFields/Parameters.lean
+++ b/Lean/QuadraticNumberFields/Parameters.lean
@@ -118,9 +118,11 @@ lemma not_isSquare_neg_one_rat : ¬ IsSquare (- (1 : ℚ)) := by
 /-- A squarefree integer that is a perfect square (as an integer) must equal `1`. -/
 lemma nat_eq_one_of_squarefree_intcast_of_isSquare (m : ℕ)
     (hsm : Squarefree (m : ℤ)) (hsq : IsSquare (m : ℤ)) : m = 1 := by
-  have hmz : (m : ℤ) = 1 :=
+  have hmz : (m : ℤ) = 1 ∨ (m : ℤ) = -1 :=
     eq_one_of_squarefree_isSquare hsm hsq
-  exact_mod_cast hmz
+  cases hmz with
+  | inl h => exact_mod_cast h
+  | inr h => simp only [Int.cast_neg] at h; omega
 
 /-- If `d₁/d₂` is a rational square and `d₂` is squarefree, then `d₂ ∣ d₁`. -/
 lemma int_dvd_of_ratio_square (d₁ d₂ : ℤ) (hd₂ : d₂ ≠ 0)

--- a/Lean/QuadraticNumberFields/Parameters.lean
+++ b/Lean/QuadraticNumberFields/Parameters.lean
@@ -122,7 +122,7 @@ lemma nat_eq_one_of_squarefree_intcast_of_isSquare (m : ℕ)
     eq_one_of_squarefree_isSquare hsm hsq
   cases hmz with
   | inl h => exact_mod_cast h
-  | inr h => simp only [Int.cast_neg] at h; omega
+  | inr h => simp only at h; omega
 
 /-- If `d₁/d₂` is a rational square and `d₂` is squarefree, then `d₂ ∣ d₁`. -/
 lemma int_dvd_of_ratio_square (d₁ d₂ : ℤ) (hd₂ : d₂ ≠ 0)
@@ -185,16 +185,12 @@ lemma squarefree_eq_of_rat_sq_mul {d₁ d₂ : ℤ}
 
 section ParamLevel
 
-variable (d₁ d₂ : ℤ) [Fact (Squarefree d₁)] [Fact (d₁ ≠ 1)]
-  [Fact (Squarefree d₂)] [Fact (d₂ ≠ 1)]
+variable (d₁ d₂ : ℤ)
 
 /-- The squarefree integer parameter of a quadratic field is unique:
     `ℚ(√d₁) ≃ₐ[ℚ] ℚ(√d₂)` with both squarefree and `≠ 1` implies `d₁ = d₂`. -/
-theorem Qsqrtd.param_unique (φ : Qsqrtd (d₁ : ℚ) ≃ₐ[ℚ] Qsqrtd (d₂ : ℚ)) : d₁ = d₂ := by
-  have hsf₁ : Squarefree d₁ := Fact.out
-  have h1₁ : d₁ ≠ 1 := Fact.out
-  have hsf₂ : Squarefree d₂ := Fact.out
-  have _h1₂ : d₂ ≠ 1 := Fact.out
+theorem Qsqrtd.param_unique (φ : Qsqrtd (d₁ : ℚ) ≃ₐ[ℚ] Qsqrtd (d₂ : ℚ))
+    (hsf₁ : Squarefree d₁) (h1₁ : d₁ ≠ 1) (hsf₂ : Squarefree d₂) : d₁ = d₂ := by
   set a := (φ ⟨0, 1⟩).re
   set b := (φ ⟨0, 1⟩).im
   have hε_sq : (⟨0, 1⟩ : Qsqrtd (d₁ : ℚ)) * ⟨0, 1⟩ = ⟨(d₁ : ℚ), 0⟩ := by

--- a/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/Classification.lean
@@ -48,6 +48,8 @@ private theorem ringOfIntegers_equiv_of_embedding
     (h_exists : ∀ x : K, IsIntegral ℤ x → ∃ z : R, φ z = x)
     (h_integral : ∀ z : R, IsIntegral ℤ (φ z)) :
     Nonempty (𝓞 K ≃+* R) := by
+  -- The hypotheses say precisely that the image of `R` inside `K`
+  -- is the full integral closure of `ℤ` in `K`.
   letI : Algebra R K := φ.toAlgebra
   letI : IsIntegralClosure R ℤ K :=
     { algebraMap_injective := by
@@ -73,6 +75,8 @@ theorem ringOfIntegers_equiv_zsqrtd_of_mod_four_ne_one (hd4 : d % 4 ≠ 1) :
     Nonempty (𝓞 (Qsqrtd (d : ℚ)) ≃+* Zsqrtd d) := by
   have hd_sf : Squarefree d := Fact.out
   have hd_ne : d ≠ 1 := Fact.out
+  -- In this branch every integral element lifts to `ℤ[√d]`, and every element
+  -- of `ℤ[√d]` is integral, so `ℤ[√d]` is the integral closure.
   exact ringOfIntegers_equiv_of_embedding (Qsqrtd (d : ℚ)) (Zsqrtd d)
     (Zsqrtd.toQsqrtdHom d)
     (Zsqrtd.toQsqrtdHom_injective d)
@@ -129,11 +133,15 @@ theorem not_isDedekindDomain_zsqrtd_of_mod_four_eq_one
   intro hDed
   letI : IsDedekindDomain (Zsqrtd d) := hDed
   letI : Module (Zsqrtd d) (Zsqrtd d) := Semiring.toModule
+  -- A Dedekind domain is integrally closed in its fraction field, so to get
+  -- a contradiction it suffices to exhibit an integral element missing from `ℤ[√d]`.
   have hIC : IsIntegrallyClosed (Zsqrtd d) := IsDedekindRing.toIsIntegralClosure
   letI : IsIntegrallyClosed (Zsqrtd d) := hIC
   rcases exists_k_of_mod_four_eq_one (d := d) hd4 with ⟨k, hk⟩
   subst hk
   let x : Qsqrtd (((1 + 4 * k : ℤ) : ℚ)) := halfInt (1 + 4 * k) 1 1
+  -- The witness is `x = (1 + √d)/2`, which is integral because it lies in
+  -- the larger order `ℤ[(1 + √d)/2]`.
   have hx_def :
       x = _root_.ZOnePlusSqrtOverTwo.toQsqrtdFun k (⟨0, 1⟩ : _root_.ZOnePlusSqrtOverTwo k) := by
     ext <;> simp [x, halfInt, _root_.ZOnePlusSqrtOverTwo.toQsqrtdFun]
@@ -144,6 +152,8 @@ theorem not_isDedekindDomain_zsqrtd_of_mod_four_eq_one
   have hx_integral : IsIntegral (Zsqrtd (1 + 4 * k)) x := hx_integral_Z.tower_top
   rcases (isIntegrallyClosed_iff (Qsqrtd (((1 + 4 * k : ℤ) : ℚ)))).mp hIC hx_integral with
     ⟨z, hz⟩
+  -- If `x` were in `ℤ[√d]`, the half-integer criterion would force both
+  -- numerators `1, 1` to be even, impossible.
   have h_even : 2 ∣ (1 : ℤ) ∧ 2 ∣ (1 : ℤ) :=
     (Zsqrtd.halfInt_mem_range_toQsqrtdHom_iff_even_even (1 + 4 * k) 1 1).mp
       ⟨z, by
@@ -172,6 +182,8 @@ theorem ringOfIntegers_equiv_zOnePlusSqrtOverTwo_of_mod_four_eq_one
   refine ⟨k, hk, ?_⟩
   subst hk
   have hd_ne' : (1 + 4 * k) ≠ 1 := hd_ne
+  -- In the `1 mod 4` branch the previous integrality criterion identifies
+  -- the full integral closure with `ℤ[(1 + √d)/2]`.
   exact ringOfIntegers_equiv_of_embedding
     (Qsqrtd (((1 + 4 * k : ℤ) : ℚ))) (ZOnePlusSqrtOverTwo k)
     (_root_.ZOnePlusSqrtOverTwo.toQsqrtdHom k)
@@ -195,6 +207,8 @@ theorem ringOfIntegers_classification
       Nonempty (𝓞 (Qsqrtd (d : ℚ)) ≃+* Zsqrtd d)) ∨
     (∃ k : ℤ, d = 1 + 4 * k ∧
       Nonempty (𝓞 (Qsqrtd (d : ℚ)) ≃+* ZOnePlusSqrtOverTwo k)) := by
+  -- The congruence class of `d mod 4` gives the two mutually exclusive shapes
+  -- of the quadratic order.
   by_cases hd4 : d % 4 = 1
   · exact Or.inr <| ringOfIntegers_equiv_zOnePlusSqrtOverTwo_of_mod_four_eq_one d hd4
   · exact Or.inl ⟨hd4, ringOfIntegers_equiv_zsqrtd_of_mod_four_ne_one d hd4⟩

--- a/Lean/QuadraticNumberFields/RingOfIntegers/HalfInt.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/HalfInt.lean
@@ -49,11 +49,15 @@ abbrev omegaHalf (d : ℤ) : Qsqrtd (d : ℚ) := halfInt d 1 1
 
 /-- Trace of `halfInt` is `a'`. -/
 theorem trace_halfInt (d a' b' : ℤ) : Algebra.trace ℚ (Qsqrtd d) (halfInt d a' b') = a' := by
+  -- The trace on `Q(√d)` is twice the real part, so for `(a' + b'√d)/2`
+  -- the denominator cancels and leaves `a'`.
   simp [halfInt]
 
 /-- Norm of `halfInt` is `(a'² - d*b'²)/4`. -/
 theorem norm_halfInt (d a' b' : ℤ) :
     Qsqrtd.norm (halfInt d a' b') = (a' ^ 2 - (d : ℚ) * b' ^ 2) / 4 := by
+  -- Expand `re = a'/2` and `im = b'/2` in the formula
+  -- `N(r + s√d) = r² - d s²`.
   simp [halfInt, Qsqrtd.norm, QuadraticAlgebra.norm]
   ring
 

--- a/Lean/QuadraticNumberFields/RingOfIntegers/HalfInt.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/HalfInt.lean
@@ -48,8 +48,8 @@ abbrev omegaHalf (d : ℤ) : Qsqrtd (d : ℚ) := halfInt d 1 1
     (omegaHalf d).im = (1 : ℚ) / 2 := rfl
 
 /-- Trace of `halfInt` is `a'`. -/
-theorem trace_halfInt (d a' b' : ℤ) : Qsqrtd.trace (halfInt d a' b') = a' := by
-  simp [halfInt, Qsqrtd.trace]
+theorem trace_halfInt (d a' b' : ℤ) : Algebra.trace ℚ (Qsqrtd d) (halfInt d a' b') = a' := by
+  simp [halfInt]
 
 /-- Norm of `halfInt` is `(a'² - d*b'²)/4`. -/
 theorem norm_halfInt (d a' b' : ℤ) :

--- a/Lean/QuadraticNumberFields/RingOfIntegers/Integrality.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/Integrality.lean
@@ -118,9 +118,8 @@ lemma isIntegral_toQsqrtd (d : ℤ) (z : Zsqrtd d) :
 
 /-- Trace in `Q(√d)` is `2 * re`. -/
 private theorem trace_eq_two_re {d : ℤ} (x : Qsqrtd (d : ℚ)) :
-    Qsqrtd.trace x = 2 * x.re := by
-  simp [Qsqrtd.trace]
-  ring
+    Algebra.trace ℚ (Qsqrtd d) x = 2 * x.re :=
+  Qsqrtd.trace_eq_two_re x
 
 /-- Norm in `Q(√d)` is `re² - d * im²`. -/
 private theorem norm_eq_sqr_minus_d_sqr {d : ℤ} (x : Qsqrtd (d : ℚ)) :
@@ -155,18 +154,18 @@ lemma exists_halfInt_with_div_four_of_isIntegral
     exact (QuadraticAlgebra.C_inj (R := ℚ) (a := (d : ℚ)) (b := (0 : ℚ))).1 hrs
   have hstar : IsIntegral ℤ (star x) := map_isIntegral_int (starRingEnd (Qsqrtd (d : ℚ))) hx
   have htraceAlg :
-      IsIntegral ℤ (QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ)) (Qsqrtd.trace x)) := by
+      IsIntegral ℤ (QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ)) (Algebra.trace ℚ (Qsqrtd d) x)) := by
     have hsum : IsIntegral ℤ (x + star x) := hx.add hstar
     have hsum_eq :
-        x + star x = QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ)) (Qsqrtd.trace x) := by
+        x + star x = QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ)) (Algebra.trace ℚ (Qsqrtd d) x) := by
       ext
-      · simp [Qsqrtd.trace, star, QuadraticAlgebra.C]
+      · simp [Qsqrtd.trace_eq_re_add_re_star, star, QuadraticAlgebra.C]
       · simp [star, QuadraticAlgebra.C]
     simpa [hsum_eq] using hsum
-  have htraceRat : IsIntegral ℤ (Qsqrtd.trace x) :=
+  have htraceRat : IsIntegral ℤ (Algebra.trace ℚ (Qsqrtd d) x) :=
     (isIntegral_algHom_iff cHom.toIntAlgHom hc_inj).1 htraceAlg
   obtain ⟨a', ha'⟩ := (IsIntegrallyClosed.isIntegral_iff (R := ℤ) (K := ℚ)).1 htraceRat
-  have ha'trace : (a' : ℚ) = Qsqrtd.trace x := by simpa using ha'
+  have ha'trace : (a' : ℚ) = Algebra.trace ℚ (Qsqrtd d) x := by simpa using ha'
   have hnormAlg : IsIntegral ℤ (algebraMap ℚ (Qsqrtd (d : ℚ)) (Qsqrtd.norm x)) := by
     have hmul : algebraMap ℚ (Qsqrtd (d : ℚ)) (Qsqrtd.norm x) = x * star x := by
       simpa [Qsqrtd.norm, mul_comm] using
@@ -183,7 +182,7 @@ lemma exists_halfInt_with_div_four_of_isIntegral
   have hre : x.re = (a' : ℚ) / 2 := by
     have htr : 2 * x.re = (a' : ℚ) := by
       calc
-        2 * x.re = Qsqrtd.trace x := (trace_eq_two_re x).symm
+        2 * x.re = Algebra.trace ℚ (Qsqrtd d) x := (trace_eq_two_re x).symm
         _ = (a' : ℚ) := ha'trace.symm
     nlinarith
   have hqmul : (d : ℚ) * q ^ 2 = (m : ℚ) := by

--- a/Lean/QuadraticNumberFields/RingOfIntegers/Integrality.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/Integrality.lean
@@ -47,6 +47,8 @@ theorem dvd_four_sub_sq_iff_exists_zsqrtd_image_of_ne_one_mod_four
     (d a' b' : ℤ) (hd : Squarefree d) (hd4 : d % 4 ≠ 1) :
     4 ∣ (a' ^ 2 - d * b' ^ 2) ↔
       ∃ z : Zsqrtd d, Zsqrtd.toQsqrtdHom d z = Zsqrtd.halfInt (d := d) a' b' := by
+  -- Away from the `d ≡ 1 (mod 4)` case, divisibility by `4` forces both
+  -- half-integer coordinates to be even, so the element already comes from `ℤ[√d]`.
   rw [dvd_four_sub_sq_iff_even_even_of_ne_one_mod_four d a' b' hd hd4]
   simpa using (Zsqrtd.halfInt_mem_range_toQsqrtdHom_iff_even_even d a' b').symm
 
@@ -72,6 +74,8 @@ theorem dvd_four_sub_sq_iff_exists_zOnePlusSqrtOverTwo_image_of_one_mod_four
       ∃ z : ZOnePlusSqrtOverTwo k,
         ZOnePlusSqrtOverTwo.toQsqrtdFun k z =
           QuadraticNumberFields.RingOfIntegers.halfInt (1 + 4 * k) a' b' := by
+  -- In the `1 mod 4` case, integrality is controlled by parity agreement
+  -- of the two numerator coordinates, matching the carrier of `ℤ[(1 + √d)/2]`.
   have hd4 : (1 + 4 * k) % 4 = 1 :=
     mod_four_eq_one_of_exists_k (d := 1 + 4 * k) ⟨k, by ring⟩
   rw [dvd_four_sub_sq_iff_same_parity_of_one_mod_four (d := 1 + 4 * k) a' b' hd hd4]
@@ -100,6 +104,7 @@ theorem ringOfIntegers_equiv_of_integralClosure
     (K : Type*) [Field K] [NumberField K]
     (R : Type*) [CommRing R] [Algebra R K] [IsIntegralClosure R ℤ K] :
     Nonempty (𝓞 K ≃+* R) :=
+  -- The ring of integers is characterized by the integral-closure universal property.
   ⟨NumberField.RingOfIntegers.equiv (K := K) (R := R)⟩
 
 /-- Any image of an integral element under a ring hom remains integral over `ℤ`. -/
@@ -107,6 +112,7 @@ private lemma isIntegral_of_intModel_image
     (R S : Type*) [CommRing R] [CommRing S]
     [Algebra.IsIntegral ℤ R] (φ : R →+* S) (z : R) :
     IsIntegral ℤ (φ z) :=
+  -- Integrality is preserved by ring homomorphisms.
   map_isIntegral_int φ (Algebra.IsIntegral.isIntegral (R := ℤ) z)
 
 /-- Every element in the image of `Zsqrtd d → Q(√d)` is integral over `ℤ`. -/
@@ -137,6 +143,8 @@ lemma exists_halfInt_with_div_four_of_isIntegral
       (4 : ℤ) ∣ (a' ^ 2 - d * b' ^ 2) := by
   have hd0 : d ≠ 0 := hd_sf.ne_zero
   have hd0Q : (d : ℚ) ≠ 0 := by exact_mod_cast hd0
+  -- We first show that both trace and norm of `x` are integers.
+  -- These will recover the numerators `a'` and `b'` of the half-integer form.
   let cHom : ℚ →+* Qsqrtd (d : ℚ) :=
     { toFun := QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ))
       map_one' := by
@@ -154,10 +162,14 @@ lemma exists_halfInt_with_div_four_of_isIntegral
     exact (QuadraticAlgebra.C_inj (R := ℚ) (a := (d : ℚ)) (b := (0 : ℚ))).1 hrs
   have hstar : IsIntegral ℤ (star x) := map_isIntegral_int (starRingEnd (Qsqrtd (d : ℚ))) hx
   have htraceAlg :
-      IsIntegral ℤ (QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ)) (Algebra.trace ℚ (Qsqrtd d) x)) := by
+      IsIntegral ℤ
+        (QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ))
+          (Algebra.trace ℚ (Qsqrtd d) x)) := by
     have hsum : IsIntegral ℤ (x + star x) := hx.add hstar
     have hsum_eq :
-        x + star x = QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ)) (Algebra.trace ℚ (Qsqrtd d) x) := by
+        x + star x =
+          QuadraticAlgebra.C (a := (d : ℚ)) (b := (0 : ℚ))
+            (Algebra.trace ℚ (Qsqrtd d) x) := by
       ext
       · simp [Qsqrtd.trace_eq_re_add_re_star, star, QuadraticAlgebra.C]
       · simp [star, QuadraticAlgebra.C]
@@ -166,6 +178,7 @@ lemma exists_halfInt_with_div_four_of_isIntegral
     (isIntegral_algHom_iff cHom.toIntAlgHom hc_inj).1 htraceAlg
   obtain ⟨a', ha'⟩ := (IsIntegrallyClosed.isIntegral_iff (R := ℤ) (K := ℚ)).1 htraceRat
   have ha'trace : (a' : ℚ) = Algebra.trace ℚ (Qsqrtd d) x := by simpa using ha'
+  -- So `a'` is the integral trace, and therefore `x.re = a'/2`.
   have hnormAlg : IsIntegral ℤ (algebraMap ℚ (Qsqrtd (d : ℚ)) (Qsqrtd.norm x)) := by
     have hmul : algebraMap ℚ (Qsqrtd (d : ℚ)) (Qsqrtd.norm x) = x * star x := by
       simpa [Qsqrtd.norm, mul_comm] using
@@ -185,6 +198,8 @@ lemma exists_halfInt_with_div_four_of_isIntegral
         2 * x.re = Algebra.trace ℚ (Qsqrtd d) x := (trace_eq_two_re x).symm
         _ = (a' : ℚ) := ha'trace.symm
     nlinarith
+  -- Rearranging the norm identity shows that `q = 2 * x.im` satisfies
+  -- `d * q² = a'² - 4 n'`, hence `q² = m / d` for an integer `m`.
   have hqmul : (d : ℚ) * q ^ 2 = (m : ℚ) := by
     have hnorm' :
         (n' : ℚ) = ((a' : ℚ) / 2) ^ 2 - (d : ℚ) * x.im ^ 2 := by
@@ -207,6 +222,8 @@ lemma exists_halfInt_with_div_four_of_isIntegral
       q ^ 2 = ((d : ℚ) * q ^ 2) / (d : ℚ) := by field_simp [hd0Q]
       _ = (m : ℚ) / (d : ℚ) := by simp [hqmul]
   have hsqratio : IsSquare ((m : ℚ) / (d : ℚ)) := ⟨q, by simpa [pow_two] using hqratio.symm⟩
+  -- Since `d` is squarefree and `(m : ℚ) / d` is a square, the denominator obstruction
+  -- disappears: `d` must divide `m`.
   have hdm : d ∣ m := int_dvd_of_ratio_square m d hd0 hd_sf hsqratio
   rcases hdm with ⟨k, hk⟩
   have hq2 : q ^ 2 = (k : ℚ) := by
@@ -216,6 +233,8 @@ lemma exists_halfInt_with_div_four_of_isIntegral
       q ^ 2 = (m : ℚ) / (d : ℚ) := hqratio
       _ = (((d : ℚ) * k) / (d : ℚ)) := by simp [hmk]
       _ = (k : ℚ) := by field_simp [hd0Q]
+  -- Therefore `q` is itself integral over `ℤ`; as `ℤ` is integrally closed in `ℚ`,
+  -- `q` must actually be an integer `b'`.
   have hqInt : IsIntegral ℤ q := by
     refine ⟨Polynomial.X ^ 2 - Polynomial.C k,
       Polynomial.monic_X_pow_sub_C (R := ℤ) (n := 2) k (show (2 : ℕ) ≠ 0 by decide), ?_⟩
@@ -232,6 +251,7 @@ lemma exists_halfInt_with_div_four_of_isIntegral
   have him : x.im = (b' : ℚ) / 2 := by
     have : (b' : ℚ) = 2 * x.im := by simpa [q] using hb'q
     nlinarith [this]
+  -- Now both coordinates match the half-integer representative `(a' + b'√d)/2`.
   have hxHalf : x = Zsqrtd.halfInt (d := d) a' b' := by
     ext <;> simp [Zsqrtd.halfInt, hre, him]
   have hnormHalf : (n' : ℚ) = (((a' ^ 2 - d * b' ^ 2 : ℤ) : ℚ) / (4 : ℤ)) := by
@@ -245,6 +265,8 @@ lemma exists_halfInt_with_div_four_of_isIntegral
   have hden : ((((a' ^ 2 - d * b' ^ 2 : ℤ) : ℚ) / (4 : ℤ)).den = 1) := by
     rw [hhalf]
     simp
+  -- The norm is an integer, so the denominator of `(a'² - d b'²) / 4` is `1`,
+  -- which is exactly the desired divisibility by `4`.
   have hdiv : (4 : ℤ) ∣ (a' ^ 2 - d * b' ^ 2) :=
     (Rat.den_div_intCast_eq_one_iff (a' ^ 2 - d * b' ^ 2) 4 (by norm_num)).1 hden
   exact ⟨a', b', hxHalf, hdiv⟩
@@ -260,6 +282,8 @@ private lemma exists_intModel_of_isIntegral
         ∃ z : R, φ z = Zsqrtd.halfInt (d := d) a' b')
     {x : Qsqrtd (d : ℚ)} (hx : IsIntegral ℤ x) :
     ∃ z : R, φ z = x := by
+  -- First put `x` into half-integer normal form, then use the branch-specific
+  -- lifting criterion supplied by `h_lift`.
   rcases exists_halfInt_with_div_four_of_isIntegral d hd_sf hd_ne (x := x) hx with
     ⟨a', b', hxHalf, hdiv⟩
   rcases h_lift a' b' hdiv with ⟨z, hz⟩

--- a/Lean/QuadraticNumberFields/RingOfIntegers/ZOnePlusSqrtOverTwo.lean
+++ b/Lean/QuadraticNumberFields/RingOfIntegers/ZOnePlusSqrtOverTwo.lean
@@ -57,6 +57,8 @@ abbrev qParam (d : ℤ) : ℚ := Qsqrtd.d_of_k d
 
 /-- Coordinate-level embedding candidate into `Q(√(1 + 4d))`. -/
 def toQsqrtdFun (d : ℤ) : ZOnePlusSqrtOverTwo d → Qsqrtd (qParam d) :=
+  -- Send `r + sω` to `r + s * (1 + √(1 + 4d)) / 2`,
+  -- so the real coordinate is `r + s/2` and the `√d`-coordinate is `s/2`.
   fun x => ⟨(x.re : ℚ) + (x.im : ℚ) / 2, (x.im : ℚ) / 2⟩
 
 /-- Coordinate-level embedding as a ring hom into `Q(√(1 + 4d))`. -/
@@ -65,6 +67,8 @@ def toQsqrtdHom (d : ℤ) : ZOnePlusSqrtOverTwo d →+* Qsqrtd (qParam d) where
   map_one' := by
     ext <;> simp [toQsqrtdFun, QuadraticAlgebra.re_one, QuadraticAlgebra.im_one]
   map_mul' := by
+    -- The multiplication formulas agree because `ω² = ω + d`,
+    -- which is exactly the relation defining `QuadraticAlgebra ℤ d 1`.
     intro x y
     ext <;>
       simp [toQsqrtdFun, qParam, Qsqrtd.d_of_k,
@@ -82,6 +86,8 @@ def toQsqrtdHom (d : ℤ) : ZOnePlusSqrtOverTwo d →+* Qsqrtd (qParam d) where
 /-- The canonical map `toQsqrtdHom` is injective. -/
 theorem toQsqrtdHom_injective (d : ℤ) : Function.Injective (toQsqrtdHom d) := by
   intro x y hxy
+  -- Equality of images first identifies the `ω`-coefficients from the imaginary parts,
+  -- then the constant terms from the real parts.
   have himHalf : (x.im : ℚ) / 2 = (y.im : ℚ) / 2 := by
     simpa [toQsqrtdHom, toQsqrtdFun] using congrArg QuadraticAlgebra.im hxy
   have himQ : (x.im : ℚ) = (y.im : ℚ) := by
@@ -105,6 +111,8 @@ theorem halfInt_mem_carrierSet_iff_same_parity (k a' b' : ℤ) :
       a' % 2 = b' % 2 := by
   constructor
   · rintro ⟨z, hz⟩
+    -- If `(a' + b'√d)/2 = r + sω`, then necessarily `s = b'`
+    -- and `a' = 2r + b'`, so `a'` and `b'` have the same parity.
     have him : z.im / 2 = (b' : ℚ) / 2 := by
       simpa [toQsqrtdFun, QuadraticNumberFields.RingOfIntegers.halfInt] using
         congrArg QuadraticAlgebra.im hz
@@ -120,6 +128,8 @@ theorem halfInt_mem_carrierSet_iff_same_parity (k a' b' : ℤ) :
     have ha' : 2 * z.re + b' = a' := by simpa [hb] using ha
     omega
   · intro hpar
+    -- Conversely, same parity means `a' - b' = 2t`, so
+    -- `(a' + b'√d)/2 = t + b' * ω`.
     have hmod : (a' - b') % 2 = 0 := by
       omega
     have hdiv : (2 : ℤ) ∣ (a' - b') := Int.dvd_iff_emod_eq_zero.mpr hmod


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request aligns the `QuadraticNumberFields` library with recent changes in Mathlib, specifically regarding `NumberField` and `QuadraticAlgebra` definitions.

Key changes include:

*   **Generalization of Number Field Instances**: The `NumberField` instance for `Qsqrtd d` is replaced by a more general `IsQuadraticField.instNumberField`, which states that any type `K` that is a quadratic extension of `ℚ` is a number field. Similarly, `QuadraticAlgebra.instIsQuadraticExtension` now proves that any `QuadraticAlgebra ℚ a b` that is a field is a quadratic extension of `ℚ`.
*   **Direct Use of Mathlib Definitions**: The custom `Qsqrtd.trace` abbreviation and `Qsqrtd.embed` are removed in favor of directly using Mathlib's `Algebra.trace` and `algebraMap`, respectively. This simplifies the codebase and improves consistency.
*   **Refinement of Squarefree Lemma**: The lemma `eq_one_of_squarefree_isSquare` is refined to correctly state that a squarefree integer that is a perfect square must be `1` or `-1`.
*   **Diamond Resolution**: The `module_eq` theorem, which resolves a diamond issue between `Algebra.toModule` and `QuadraticAlgebra.instModule`, is generalized to `QuadraticAlgebra ℚ a b`.
*   **Docstring and Structure Updates**: Docstrings are updated to reflect the broader scope and improved alignment with Mathlib, and the `instFact_of_not_isSquare` bridge instance is moved to `Basic.lean` for better organization.

This PR streamlines the definitions and instances, making the library more robust and integrated with Mathlib's number theory framework.
<!-- kody-pr-summary:end -->