### PR TITLE
Introduce binary quadratic form core

### DIFF
--- a/BinaryQuadraticForms.lean
+++ b/BinaryQuadraticForms.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.Action
+import BinaryQuadraticForms.Core.Basic
+import BinaryQuadraticForms.Core.Class
+import BinaryQuadraticForms.Core.QuadraticFormBridge
+
+/-!
+# Binary Quadratic Forms
+
+This library develops the computable coordinate model of integral binary
+quadratic forms used by the quadratic-number-fields project.
+-/

--- a/BinaryQuadraticForms/Core/Action.lean
+++ b/BinaryQuadraticForms/Core/Action.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.Basic
+import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+
+/-!
+# Proper Equivalence of Binary Quadratic Forms
+
+This file defines the explicit `SL₂(ℤ)` coordinate action on binary quadratic
+forms and proves the elementary invariants needed by proper equivalence.
+-/
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+open Matrix
+
+/-- The integral special linear group in dimension two. -/
+abbrev SL2Z := Matrix.SpecialLinearGroup (Fin 2) ℤ
+
+private abbrev m00 (g : SL2Z) : ℤ := (g : Matrix (Fin 2) (Fin 2) ℤ) 0 0
+private abbrev m01 (g : SL2Z) : ℤ := (g : Matrix (Fin 2) (Fin 2) ℤ) 0 1
+private abbrev m10 (g : SL2Z) : ℤ := (g : Matrix (Fin 2) (Fin 2) ℤ) 1 0
+private abbrev m11 (g : SL2Z) : ℤ := (g : Matrix (Fin 2) (Fin 2) ℤ) 1 1
+
+/-- Coordinate transform of a form by an `SL₂(ℤ)` matrix. -/
+def transform (Q : BinaryQuadraticForm) (g : SL2Z) : BinaryQuadraticForm where
+  a := Q.a * m00 g ^ 2 + Q.b * m00 g * m10 g + Q.c * m10 g ^ 2
+  b := 2 * Q.a * m00 g * m01 g +
+    Q.b * (m00 g * m11 g + m01 g * m10 g) +
+    2 * Q.c * m10 g * m11 g
+  c := Q.a * m01 g ^ 2 + Q.b * m01 g * m11 g + Q.c * m11 g ^ 2
+
+@[simp] theorem transform_one (Q : BinaryQuadraticForm) :
+    transform Q (1 : SL2Z) = Q := by
+  cases Q
+  ext <;> norm_num [transform, m00, m01, m10, m11]
+
+/-- The coordinate transform is compatible with multiplication in `SL₂(ℤ)`. -/
+theorem transform_mul (Q : BinaryQuadraticForm) (g h : SL2Z) :
+    transform (transform Q g) h = transform Q (g * h) := by
+  rcases Q with ⟨A, B, C⟩
+  ext <;>
+    simp [transform, m00, m01, m10, m11, Matrix.mul_apply, Fin.sum_univ_two] <;>
+    ring_nf
+
+/-- Proper equivalence: forms lie in the same `SL₂(ℤ)` orbit. -/
+def ProperEquivalent (Q R : BinaryQuadraticForm) : Prop :=
+  ∃ g : SL2Z, transform Q g = R
+
+/-- Proper equivalence is reflexive. -/
+theorem ProperEquivalent.refl (Q : BinaryQuadraticForm) : ProperEquivalent Q Q :=
+  ⟨1, transform_one Q⟩
+
+/-- Proper equivalence is symmetric. -/
+theorem ProperEquivalent.symm {Q R : BinaryQuadraticForm}
+    (hQR : ProperEquivalent Q R) : ProperEquivalent R Q := by
+  rcases hQR with ⟨g, rfl⟩
+  refine ⟨g⁻¹, ?_⟩
+  rw [transform_mul, mul_inv_cancel, transform_one]
+
+/-- Proper equivalence is transitive. -/
+theorem ProperEquivalent.trans {Q R S : BinaryQuadraticForm}
+    (hQR : ProperEquivalent Q R) (hRS : ProperEquivalent R S) :
+    ProperEquivalent Q S := by
+  rcases hQR with ⟨g, rfl⟩
+  rcases hRS with ⟨h, rfl⟩
+  exact ⟨g * h, (transform_mul Q g h).symm⟩
+
+/-- A positive definite form evaluates positively on every nonzero vector. -/
+theorem eval_pos_of_isPositiveDefinite (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) {x y : ℤ} (hxy : x ≠ 0 ∨ y ≠ 0) :
+    0 < Q.eval x y := by
+  rcases Q with ⟨a, b, c⟩
+  rcases hQ with ⟨ha, hdisc⟩
+  simp only [disc_mk] at hdisc
+  simp only [eval_mk]
+  have hcoef : 0 < 4 * a * c - b ^ 2 := by nlinarith
+  have hmain : 0 < (2 * a * x + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by
+    by_cases hy : y = 0
+    · rcases hxy with hx | hy'
+      · have hnonzero : 2 * a * x ≠ 0 :=
+          mul_ne_zero (mul_ne_zero (by norm_num) (ne_of_gt ha)) hx
+        have hs : 0 < (2 * a * x + b * y) ^ 2 := by
+          rw [hy, mul_zero, add_zero]
+          exact sq_pos_of_ne_zero hnonzero
+        nlinarith
+      · contradiction
+    · have hy2 : 0 < y ^ 2 := sq_pos_of_ne_zero hy
+      nlinarith [sq_nonneg (2 * a * x + b * y)]
+  have hident :
+      (2 * a * x + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 =
+        4 * a * (a * x ^ 2 + b * x * y + c * y ^ 2) := by
+    ring
+  have hprod : 0 < 4 * a * (a * x ^ 2 + b * x * y + c * y ^ 2) := by
+    rwa [hident] at hmain
+  nlinarith
+
+private theorem disc_transform_aux (a b c p q r s : ℤ) (hdet : p * s - q * r = 1) :
+    (2 * a * p * q + b * (p * s + q * r) + 2 * c * r * s) ^ 2 -
+        4 * (a * p ^ 2 + b * p * r + c * r ^ 2) *
+          (a * q ^ 2 + b * q * s + c * s ^ 2) =
+      b ^ 2 - 4 * a * c := by
+  calc
+    (2 * a * p * q + b * (p * s + q * r) + 2 * c * r * s) ^ 2 -
+        4 * (a * p ^ 2 + b * p * r + c * r ^ 2) *
+          (a * q ^ 2 + b * q * s + c * s ^ 2)
+        = (b ^ 2 - 4 * a * c) * (p * s - q * r) ^ 2 := by ring
+    _ = b ^ 2 - 4 * a * c := by
+      rw [hdet]
+      ring
+
+/-- The `SL₂(ℤ)` coordinate transform preserves discriminants. -/
+theorem disc_transform (Q : BinaryQuadraticForm) (g : SL2Z) :
+    (transform Q g).disc = Q.disc := by
+  let p : ℤ := m00 g
+  let q : ℤ := m01 g
+  let r : ℤ := m10 g
+  let s : ℤ := m11 g
+  have hdet : p * s - q * r = 1 := by
+    have h := g.2
+    rw [Matrix.det_fin_two] at h
+    simpa [p, q, r, s, m00, m01, m10, m11] using h
+  rcases Q with ⟨A, B, C⟩
+  simpa [transform, disc, p, q, r, s] using disc_transform_aux A B C p q r s hdet
+
+/-- Properly equivalent forms have equal discriminants. -/
+theorem disc_eq_of_properEquivalent {Q R : BinaryQuadraticForm}
+    (hQR : ProperEquivalent Q R) : Q.disc = R.disc := by
+  rcases hQR with ⟨g, rfl⟩
+  exact (disc_transform Q g).symm
+
+/-- The `SL₂(ℤ)` coordinate transform preserves positive definiteness. -/
+theorem isPositiveDefinite_transform (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (g : SL2Z) : (transform Q g).IsPositiveDefinite := by
+  constructor
+  · rw [show (transform Q g).a = Q.eval (m00 g) (m10 g) by rfl]
+    apply eval_pos_of_isPositiveDefinite Q hQ
+    by_contra hzero
+    push Not at hzero
+    have hdet := g.2
+    rw [Matrix.det_fin_two] at hdet
+    simp [hzero.1, hzero.2] at hdet
+  · rw [disc_transform]
+    exact hQ.2
+
+/-- Proper equivalence preserves positive definiteness. -/
+theorem isPositiveDefinite_of_properEquivalent {Q R : BinaryQuadraticForm}
+    (hQ : Q.IsPositiveDefinite) (hQR : ProperEquivalent Q R) : R.IsPositiveDefinite := by
+  rcases hQR with ⟨g, rfl⟩
+  exact isPositiveDefinite_transform Q hQ g
+
+private theorem dvd_coefficients_of_dvd_transform_coefficients
+    (Q : BinaryQuadraticForm) (g : SL2Z) {n : ℕ}
+    (ha : (n : ℤ) ∣ (transform Q g).a) (hb : (n : ℤ) ∣ (transform Q g).b)
+    (hc : (n : ℤ) ∣ (transform Q g).c) :
+    (n : ℤ) ∣ Q.a ∧ (n : ℤ) ∣ Q.b ∧ (n : ℤ) ∣ Q.c := by
+  have hback : transform (transform Q g) g⁻¹ = Q := by
+    rw [transform_mul, mul_inv_cancel, transform_one]
+  constructor
+  · rw [← congrArg BinaryQuadraticForm.a hback]
+    convert
+      dvd_add (dvd_add (dvd_mul_of_dvd_left ha (m00 g⁻¹ ^ 2))
+        (dvd_mul_of_dvd_left hb (m00 g⁻¹ * m10 g⁻¹)))
+        (dvd_mul_of_dvd_left hc (m10 g⁻¹ ^ 2)) using 1
+    · simp [transform]
+      ring_nf
+  · constructor
+    · rw [← congrArg BinaryQuadraticForm.b hback]
+      convert
+        dvd_add (dvd_add (dvd_mul_of_dvd_left ha (2 * m00 g⁻¹ * m01 g⁻¹))
+          (dvd_mul_of_dvd_left hb (m00 g⁻¹ * m11 g⁻¹ + m01 g⁻¹ * m10 g⁻¹)))
+          (dvd_mul_of_dvd_left hc (2 * m10 g⁻¹ * m11 g⁻¹)) using 1
+      · simp [transform]
+        ring_nf
+    · rw [← congrArg BinaryQuadraticForm.c hback]
+      convert
+        dvd_add (dvd_add (dvd_mul_of_dvd_left ha (m01 g⁻¹ ^ 2))
+          (dvd_mul_of_dvd_left hb (m01 g⁻¹ * m11 g⁻¹)))
+          (dvd_mul_of_dvd_left hc (m11 g⁻¹ ^ 2)) using 1
+      · simp [transform]
+        ring_nf
+
+/-- The `SL₂(ℤ)` coordinate transform preserves primitivity. -/
+theorem isPrimitive_transform (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPrimitive) (g : SL2Z) : (transform Q g).IsPrimitive := by
+  unfold IsPrimitive at hQ ⊢
+  let P := transform Q g
+  let n : ℕ := Int.gcd P.a (Int.gcd P.b P.c)
+  have haP : (n : ℤ) ∣ P.a := Int.gcd_dvd_left _ _
+  have hbcP : (n : ℤ) ∣ Int.gcd P.b P.c := Int.gcd_dvd_right _ _
+  have hbP : (n : ℤ) ∣ P.b := dvd_trans hbcP (Int.gcd_dvd_left _ _)
+  have hcP : (n : ℤ) ∣ P.c := dvd_trans hbcP (Int.gcd_dvd_right _ _)
+  have hQdvd := dvd_coefficients_of_dvd_transform_coefficients Q g haP hbP hcP
+  have hngcd_bc : n ∣ Int.gcd Q.b Q.c := Int.dvd_gcd hQdvd.2.1 hQdvd.2.2
+  have hngcd : n ∣ Int.gcd Q.a (Int.gcd Q.b Q.c) :=
+    Int.dvd_gcd hQdvd.1 (by exact_mod_cast hngcd_bc)
+  rw [hQ] at hngcd
+  exact Nat.dvd_one.mp hngcd
+
+/-- Proper equivalence preserves primitivity. -/
+theorem isPrimitive_of_properEquivalent {Q R : BinaryQuadraticForm}
+    (hQ : Q.IsPrimitive) (hQR : ProperEquivalent Q R) : R.IsPrimitive := by
+  rcases hQR with ⟨g, rfl⟩
+  exact isPrimitive_transform Q hQ g
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/BinaryQuadraticForms/Core/Basic.lean
+++ b/BinaryQuadraticForms/Core/Basic.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import Mathlib.Data.Int.Basic
+import Mathlib.Data.Int.GCD
+import Mathlib.Tactic.NormNum
+
+/-!
+# Binary Quadratic Forms
+
+This file defines the project-owned integer-triple model of binary quadratic
+forms used for the Cox/Gauss class-group bridge.
+
+## Implementation notes
+
+Mathlib already has `QuadraticForm`, but this subsystem intentionally keeps a
+small coordinate model for classical integral binary forms.  The direct
+`(a, b, c)` representation gives computable coefficient access and derives
+`DecidableEq` and `Repr`, which are used by the reduced-form enumeration and
+compile-time regression checks.  A bridge to mathlib's structural `QuadraticForm`
+API should be added explicitly when needed rather than replacing this
+computable model wholesale.
+-/
+
+namespace QuadraticNumberFields
+
+/-- An integral binary quadratic form `a X² + b X Y + c Y²`. -/
+structure BinaryQuadraticForm where
+  /-- The `X²` coefficient. -/
+  a : ℤ
+  /-- The `XY` coefficient. -/
+  b : ℤ
+  /-- The `Y²` coefficient. -/
+  c : ℤ
+deriving DecidableEq, Repr
+
+-- The `prec` argument of the derived `Repr` instance is unused for a plain
+-- product structure; this is inherent to the `Repr.reprPrec` signature.
+attribute [nolint unusedArguments] instReprBinaryQuadraticForm.repr
+
+namespace BinaryQuadraticForm
+
+@[ext] theorem ext {Q R : BinaryQuadraticForm}
+    (ha : Q.a = R.a) (hb : Q.b = R.b) (hc : Q.c = R.c) : Q = R := by
+  cases Q
+  cases R
+  simp_all
+
+/-- The discriminant `b² - 4ac` of a binary quadratic form. -/
+def disc (Q : BinaryQuadraticForm) : ℤ :=
+  Q.b ^ 2 - 4 * Q.a * Q.c
+
+/-- Evaluation of `a X² + b X Y + c Y²` at integer coordinates. -/
+def eval (Q : BinaryQuadraticForm) (x y : ℤ) : ℤ :=
+  Q.a * x ^ 2 + Q.b * x * y + Q.c * y ^ 2
+
+/-- A form has a prescribed discriminant. -/
+def HasDiscriminant (Q : BinaryQuadraticForm) (D : ℤ) : Prop :=
+  Q.disc = D
+
+/-- Positive definiteness in the imaginary quadratic setting. -/
+def IsPositiveDefinite (Q : BinaryQuadraticForm) : Prop :=
+  0 < Q.a ∧ Q.disc < 0
+
+/-- Primitive forms have coprime coefficients. -/
+def IsPrimitive (Q : BinaryQuadraticForm) : Prop :=
+  Int.gcd Q.a (Int.gcd Q.b Q.c) = 1
+
+@[simp] theorem disc_mk (a b c : ℤ) :
+    disc (BinaryQuadraticForm.mk a b c) = b ^ 2 - 4 * a * c := rfl
+
+@[simp] theorem eval_mk (a b c x y : ℤ) :
+    eval (BinaryQuadraticForm.mk a b c) x y =
+      a * x ^ 2 + b * x * y + c * y ^ 2 := rfl
+
+example : (BinaryQuadraticForm.mk 1 0 1).disc = -4 := by norm_num [disc]
+
+example : (BinaryQuadraticForm.mk 1 1 1).eval 2 3 = 19 := by norm_num [eval]
+
+example : (BinaryQuadraticForm.mk 1 0 1).IsPositiveDefinite := by
+  constructor <;> norm_num [IsPositiveDefinite, disc]
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/BinaryQuadraticForms/Core/Class.lean
+++ b/BinaryQuadraticForms/Core/Class.lean
@@ -1,0 +1,235 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.Action
+import QNFMathlib.Data.Int.ModFour
+
+/-!
+# Primitive Positive Definite Form Classes
+
+This file defines the restricted carrier used by the imaginary Cox 7.7 bridge:
+primitive positive definite binary quadratic forms of a fixed discriminant,
+their proper equivalence classes, and the squarefree field-discriminant
+arithmetic used by the bridge and computable layers.
+-/
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+/-! ## Primitive positive definite form classes -/
+
+/-- Primitive positive definite forms of discriminant `D`. This is the
+imaginary-side carrier used by Cox 7.7; negative definite forms of the same
+negative discriminant are not part of this class-number bridge. -/
+def PrimitivePositiveDefiniteForm (D : ℤ) : Type :=
+  { Q : BinaryQuadraticForm //
+    Q.HasDiscriminant D ∧ Q.IsPrimitive ∧ Q.IsPositiveDefinite }
+
+namespace PrimitivePositiveDefiniteForm
+
+/-- Proper equivalence restricted to primitive positive definite forms. -/
+def ProperEquivalent {D : ℤ}
+    (Q R : PrimitivePositiveDefiniteForm D) : Prop :=
+  BinaryQuadraticForm.ProperEquivalent Q.1 R.1
+
+end PrimitivePositiveDefiniteForm
+
+/-- Setoid on primitive positive definite forms given by proper equivalence. -/
+instance primitivePositiveDefiniteFormSetoid (D : ℤ) :
+    Setoid (PrimitivePositiveDefiniteForm D) where
+  r := PrimitivePositiveDefiniteForm.ProperEquivalent
+  iseqv := ⟨
+    fun Q => BinaryQuadraticForm.ProperEquivalent.refl Q.1,
+    fun h => BinaryQuadraticForm.ProperEquivalent.symm h,
+    fun hQR hRS => BinaryQuadraticForm.ProperEquivalent.trans hQR hRS⟩
+
+/-- Proper equivalence classes of primitive positive definite binary quadratic
+forms of discriminant `D`. -/
+def FormClass (D : ℤ) : Type :=
+  Quotient (primitivePositiveDefiniteFormSetoid D)
+
+/-- The field discriminant attached to a squarefree `Qsqrtd d` parameter. -/
+def fieldDiscriminant (d : ℤ) : ℤ :=
+  if d % 4 = 1 then d else 4 * d
+
+/-- In the `d % 4 = 1` branch, the field discriminant is `d`. -/
+theorem fieldDiscriminant_of_mod_four_eq_one {d : ℤ} (hd4 : d % 4 = 1) :
+    fieldDiscriminant d = d := by
+  simp [fieldDiscriminant, hd4]
+
+/-- In the `d % 4 ≠ 1` branch, the field discriminant is `4 * d`. -/
+theorem fieldDiscriminant_of_mod_four_ne_one {d : ℤ} (hd4 : d % 4 ≠ 1) :
+    fieldDiscriminant d = 4 * d := by
+  simp [fieldDiscriminant, hd4]
+
+/-- Imaginary squarefree parameters have negative field discriminant. -/
+theorem fieldDiscriminant_neg {d : ℤ} (hdneg : d < 0) :
+    fieldDiscriminant d < 0 := by
+  by_cases hd4 : d % 4 = 1
+  · rw [fieldDiscriminant_of_mod_four_eq_one hd4]
+    exact hdneg
+  · rw [fieldDiscriminant_of_mod_four_ne_one hd4]
+    nlinarith
+
+/-- In the `d % 4 ≠ 1` Cox branch, a form of field discriminant has even
+middle coefficient. This justifies the `-b / 2` coordinate in the `Zsqrtd`
+ideal generator. -/
+theorem even_b_of_hasDiscriminant_fieldDiscriminant_of_mod_four_ne_one
+    {d : ℤ} (hd4 : d % 4 ≠ 1) {Q : BinaryQuadraticForm}
+    (hdisc : Q.HasDiscriminant (fieldDiscriminant d)) : Even Q.b := by
+  have hdisc' : Q.b ^ 2 - 4 * Q.a * Q.c = 4 * d := by
+    simpa [HasDiscriminant, disc, fieldDiscriminant, hd4] using hdisc
+  by_contra hb_even
+  have hb_not_dvd : ¬ (2 : ℤ) ∣ Q.b := by simpa [even_iff_two_dvd] using hb_even
+  have hb2dvd : (4 : ℤ) ∣ Q.b ^ 2 := by
+    refine ⟨Q.a * Q.c + d, ?_⟩
+    nlinarith
+  have hb2mod0 : Q.b ^ 2 % 4 = 0 := (Int.dvd_iff_emod_eq_zero).mp hb2dvd
+  have hb2mod1 : Q.b ^ 2 % 4 = 1 := Int.sq_emod_four_of_odd Q.b hb_not_dvd
+  omega
+
+/-- In the `d % 4 = 1` Cox branch, a form of field discriminant has odd
+middle coefficient. This justifies the `-(b + 1) / 2` coordinate in the
+`ZOnePlusSqrtdOverTwo` ideal generator. -/
+theorem odd_b_of_hasDiscriminant_fieldDiscriminant_of_mod_four_eq_one
+    {d : ℤ} (hd4 : d % 4 = 1) {Q : BinaryQuadraticForm}
+    (hdisc : Q.HasDiscriminant (fieldDiscriminant d)) : Odd Q.b := by
+  rw [← Int.not_even_iff_odd]
+  intro hb_even
+  have hdisc' : Q.b ^ 2 - 4 * Q.a * Q.c = d := by
+    simpa [HasDiscriminant, disc, fieldDiscriminant, hd4] using hdisc
+  have hb_dvd : (2 : ℤ) ∣ Q.b := by simpa [even_iff_two_dvd] using hb_even
+  have hb2mod0 : Q.b ^ 2 % 4 = 0 := Int.sq_emod_four_of_even Q.b hb_dvd
+  have hb2mod1 : Q.b ^ 2 % 4 = 1 := by
+    have hmod : Q.b ^ 2 % 4 = d % 4 := by
+      have hb2_eq : Q.b ^ 2 = 4 * Q.a * Q.c + d := by nlinarith
+      rw [hb2_eq, show 4 * Q.a * Q.c + d = d + 4 * (Q.a * Q.c) by ring,
+        Int.add_mul_emod_self_left]
+    simpa [hd4] using hmod
+  omega
+
+private theorem dvd_disc_of_dvd_coefficients (Q : BinaryQuadraticForm) {n : ℕ}
+    (ha : (n : ℤ) ∣ Q.a) (hb : (n : ℤ) ∣ Q.b) (hc : (n : ℤ) ∣ Q.c) :
+    ((n : ℤ) * (n : ℤ)) ∣ Q.disc := by
+  rcases Q with ⟨A, B, C⟩
+  simp only at ha hb hc
+  obtain ⟨a, rfl⟩ := ha
+  obtain ⟨b, rfl⟩ := hb
+  obtain ⟨c, rfl⟩ := hc
+  refine ⟨b ^ 2 - 4 * a * c, ?_⟩
+  simp [disc]
+  ring
+
+private theorem not_two_dvd_common_coefficients_of_fieldDiscriminant_ne_one
+    {d : ℤ} [Fact (Squarefree d)] (hd4 : d % 4 ≠ 1) (Q : BinaryQuadraticForm)
+    (hdisc : Q.HasDiscriminant (fieldDiscriminant d))
+    (ha : (2 : ℤ) ∣ Q.a) (hb : (2 : ℤ) ∣ Q.b) (hc : (2 : ℤ) ∣ Q.c) :
+    False := by
+  rcases Q with ⟨A, B, C⟩
+  simp only at ha hb hc
+  obtain ⟨a, rfl⟩ := ha
+  obtain ⟨b, rfl⟩ := hb
+  obtain ⟨c, rfl⟩ := hc
+  have hd_eq : d = b ^ 2 - 4 * a * c := by
+    have hdisc' : (2 * b) ^ 2 - 4 * (2 * a) * (2 * c) = 4 * d := by
+      simpa [HasDiscriminant, disc, fieldDiscriminant, hd4] using hdisc
+    nlinarith
+  by_cases hb_even : (2 : ℤ) ∣ b
+  · have hb2mod0 : b ^ 2 % 4 = 0 := Int.sq_emod_four_of_even b hb_even
+    have hdmod : d % 4 = 0 := by
+      rw [hd_eq, show b ^ 2 - 4 * a * c = b ^ 2 + 4 * (-(a * c)) by ring]
+      omega
+    have hdvd : (4 : ℤ) ∣ d := (Int.dvd_iff_emod_eq_zero).mpr hdmod
+    exact squarefree_int_not_dvd_four d (Fact.out : Squarefree d) hdvd
+  · have hb2mod1 : b ^ 2 % 4 = 1 := Int.sq_emod_four_of_odd b hb_even
+    have hdmod : d % 4 = 1 := by
+      rw [hd_eq, show b ^ 2 - 4 * a * c = b ^ 2 + 4 * (-(a * c)) by ring]
+      omega
+    exact hd4 hdmod
+
+private theorem odd_prime_not_common_coefficients_of_fieldDiscriminant_ne_one
+    {d : ℤ} [Fact (Squarefree d)] (hd4 : d % 4 ≠ 1) (Q : BinaryQuadraticForm)
+    (hdisc : Q.HasDiscriminant (fieldDiscriminant d)) {p : ℕ} (hp : Nat.Prime p)
+    (hp2 : p ≠ 2)
+    (ha : (p : ℤ) ∣ Q.a) (hb : (p : ℤ) ∣ Q.b) (hc : (p : ℤ) ∣ Q.c) :
+    False := by
+  rcases Q with ⟨A, B, C⟩
+  simp only at ha hb hc
+  obtain ⟨a, rfl⟩ := ha
+  obtain ⟨b, rfl⟩ := hb
+  obtain ⟨c, rfl⟩ := hc
+  have hp2dvd4d : (((p * p : ℕ) : ℤ)) ∣ 4 * d := by
+    refine ⟨b ^ 2 - 4 * a * c, ?_⟩
+    have hdisc' :
+        ((p : ℤ) * b) ^ 2 - 4 * ((p : ℤ) * a) * ((p : ℤ) * c) = 4 * d := by
+      simpa [HasDiscriminant, disc, fieldDiscriminant, hd4] using hdisc
+    rw [← hdisc']
+    norm_num
+    ring
+  have hgcd : Int.gcd (((p * p : ℕ) : ℤ)) (4 : ℤ) = 1 := by
+    have hpnot2dvd : ¬ p ∣ 2 := by
+      intro h
+      rcases (Nat.dvd_prime Nat.prime_two).mp h with hp1 | hpeq2
+      · exact hp.ne_one hp1
+      · exact hp2 hpeq2
+    have hcop2 : Nat.Coprime p 2 := (Nat.Prime.coprime_iff_not_dvd hp).mpr hpnot2dvd
+    have hcoppp2 : Nat.Coprime (p * p) 2 := hcop2.mul_left hcop2
+    have hcop4 : Nat.Coprime (p * p) 4 := by
+      rw [show (4 : ℕ) = 2 * 2 by norm_num]
+      exact hcoppp2.mul_right hcoppp2
+    unfold Int.gcd
+    norm_num [Int.natAbs_mul]
+    exact hcop4.gcd_eq_one
+  have hp2dvdd : (((p * p : ℕ) : ℤ)) ∣ d := by
+    apply Int.dvd_of_dvd_mul_left_of_gcd_one
+    · simpa [mul_comm, mul_left_comm, mul_assoc] using hp2dvd4d
+    · exact hgcd
+  have hpunit : ¬ IsUnit (p : ℤ) := by
+    rw [Int.isUnit_iff]
+    rintro (hp1 | hpneg)
+    · exact hp.ne_one (Int.ofNat.inj hp1)
+    · omega
+  exact Squarefree.not_mul_self_dvd_of_not_isUnit (Fact.out : Squarefree d) hpunit (by
+    simpa using hp2dvdd)
+
+/-- A form with squarefree field discriminant is primitive. -/
+theorem isPrimitive_of_hasDiscriminant_fieldDiscriminant
+    {d : ℤ} [Fact (Squarefree d)] (Q : BinaryQuadraticForm)
+    (hdisc : Q.HasDiscriminant (fieldDiscriminant d)) : Q.IsPrimitive := by
+  unfold IsPrimitive
+  let n : ℕ := Int.gcd Q.a (Int.gcd Q.b Q.c)
+  have ha : (n : ℤ) ∣ Q.a := Int.gcd_dvd_left _ _
+  have hbc : (n : ℤ) ∣ Int.gcd Q.b Q.c := Int.gcd_dvd_right _ _
+  have hb : (n : ℤ) ∣ Q.b := dvd_trans hbc (Int.gcd_dvd_left _ _)
+  have hc : (n : ℤ) ∣ Q.c := dvd_trans hbc (Int.gcd_dvd_right _ _)
+  by_cases hd4 : d % 4 = 1
+  · have hnsq_dvd_disc : ((n : ℤ) * (n : ℤ)) ∣ Q.disc :=
+      dvd_disc_of_dvd_coefficients Q ha hb hc
+    have hnsq_dvd_d : ((n : ℤ) * (n : ℤ)) ∣ d := by
+      rw [hdisc, fieldDiscriminant_of_mod_four_eq_one hd4] at hnsq_dvd_disc
+      exact hnsq_dvd_disc
+    by_contra hn
+    have hnunit : ¬ IsUnit (n : ℤ) := by
+      rw [Int.isUnit_iff]
+      omega
+    exact Squarefree.not_mul_self_dvd_of_not_isUnit (Fact.out : Squarefree d) hnunit
+      hnsq_dvd_d
+  · by_contra hn
+    obtain ⟨p, hp, hpn⟩ := Nat.exists_prime_and_dvd hn
+    have hpz_dvd_n : (p : ℤ) ∣ (n : ℤ) := by exact_mod_cast hpn
+    have hpa : (p : ℤ) ∣ Q.a := dvd_trans hpz_dvd_n ha
+    have hpb : (p : ℤ) ∣ Q.b := dvd_trans hpz_dvd_n hb
+    have hpc : (p : ℤ) ∣ Q.c := dvd_trans hpz_dvd_n hc
+    by_cases hp2 : p = 2
+    · subst hp2
+      exact not_two_dvd_common_coefficients_of_fieldDiscriminant_ne_one
+        hd4 Q hdisc hpa hpb hpc
+    · exact
+        odd_prime_not_common_coefficients_of_fieldDiscriminant_ne_one
+          hd4 Q hdisc hp hp2 hpa hpb hpc
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/BinaryQuadraticForms/Core/QuadraticFormBridge.lean
+++ b/BinaryQuadraticForms/Core/QuadraticFormBridge.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.Action
+import Mathlib.Algebra.CharP.Invertible
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import Mathlib.Tactic.Ring
+
+/-!
+# Bridge to mathlib Quadratic Forms
+
+This file identifies the project-owned coordinate model of integral binary
+quadratic forms with mathlib's structural `QuadraticForm` API on `ℤ²`.
+
+The coordinate model remains the computable representation used by reduction,
+enumeration, and Gauss composition.  The bridge in this file is the explicit
+mathematical equivalence between a triple `(a, b, c)` and the quadratic form
+`(x, y) ↦ a*x^2 + b*x*y + c*y^2`.
+-/
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+open Matrix
+
+local instance : Invertible (2 : ℚ) :=
+  invertibleOfNonzero (by norm_num : (2 : ℚ) ≠ 0)
+
+/-! ## Coordinates and coefficient accessors -/
+
+/-- Coordinates in the standard basis of a two-dimensional coordinate module. -/
+def coordVec {R : Type*} (x y : R) : Fin 2 → R :=
+  ![x, y]
+
+/-- The mathlib structural type corresponding to integral binary quadratic forms. -/
+abbrev IntegralQuadraticForm : Type :=
+  QuadraticForm ℤ (Fin 2 → ℤ)
+
+/-- The mathlib structural type corresponding to rational binary quadratic forms. -/
+abbrev RationalQuadraticForm : Type :=
+  QuadraticForm ℚ (Fin 2 → ℚ)
+
+/-- The `X²` coefficient of a mathlib binary quadratic form over `ℤ`. -/
+def coeffA (Q : IntegralQuadraticForm) : ℤ :=
+  Q (coordVec 1 0)
+
+/-- The `XY` coefficient of a mathlib binary quadratic form over `ℤ`. -/
+def coeffB (Q : IntegralQuadraticForm) : ℤ :=
+  Q (coordVec 1 1) - Q (coordVec 1 0) - Q (coordVec 0 1)
+
+/-- The `Y²` coefficient of a mathlib binary quadratic form over `ℤ`. -/
+def coeffC (Q : IntegralQuadraticForm) : ℤ :=
+  Q (coordVec 0 1)
+
+/-- The classical binary-form discriminant `b² - 4ac`.
+
+This is intentionally separate from mathlib's `QuadraticMap.discr`, whose matrix
+determinant normalization requires an invertibility hypothesis for `2`.
+-/
+def classicalDisc (Q : IntegralQuadraticForm) : ℤ :=
+  coeffB Q ^ 2 - 4 * coeffA Q * coeffC Q
+
+/-! ## Converting between representations -/
+
+/-- Interpret a coordinate binary quadratic form as a mathlib quadratic form. -/
+def toQuadraticForm (Q : BinaryQuadraticForm) : IntegralQuadraticForm :=
+  Q.a • QuadraticMap.proj (R := ℤ) (n := Fin 2) 0 0 +
+    Q.b • QuadraticMap.proj (R := ℤ) (n := Fin 2) 0 1 +
+    Q.c • QuadraticMap.proj (R := ℤ) (n := Fin 2) 1 1
+
+/-- Recover the coordinate triple of a mathlib binary quadratic form over `ℤ`. -/
+def ofQuadraticForm (Q : IntegralQuadraticForm) : BinaryQuadraticForm where
+  a := coeffA Q
+  b := coeffB Q
+  c := coeffC Q
+
+@[simp]
+theorem toQuadraticForm_apply (Q : BinaryQuadraticForm) (v : Fin 2 → ℤ) :
+    toQuadraticForm Q v = Q.eval (v 0) (v 1) := by
+  simp [toQuadraticForm, eval]
+  ring
+
+@[simp]
+theorem toQuadraticForm_coordVec (Q : BinaryQuadraticForm) (x y : ℤ) :
+    toQuadraticForm Q (coordVec x y) = Q.eval x y := by
+  simp [coordVec]
+
+@[simp]
+theorem coeffA_toQuadraticForm (Q : BinaryQuadraticForm) :
+    coeffA (toQuadraticForm Q) = Q.a := by
+  simp [coeffA, coordVec, eval]
+
+@[simp]
+theorem coeffB_toQuadraticForm (Q : BinaryQuadraticForm) :
+    coeffB (toQuadraticForm Q) = Q.b := by
+  simp [coeffB, coordVec, eval]
+  ring_nf
+
+@[simp]
+theorem coeffC_toQuadraticForm (Q : BinaryQuadraticForm) :
+    coeffC (toQuadraticForm Q) = Q.c := by
+  simp [coeffC, coordVec, eval]
+
+@[simp]
+theorem ofQuadraticForm_toQuadraticForm (Q : BinaryQuadraticForm) :
+    ofQuadraticForm (toQuadraticForm Q) = Q := by
+  ext <;> simp [ofQuadraticForm]
+
+/-- Every mathlib binary quadratic form over `ℤ` is determined by its three
+standard coefficients. -/
+theorem apply_eq_coeffs (Q : IntegralQuadraticForm) (v : Fin 2 → ℤ) :
+    Q v = coeffA Q * (v 0) ^ 2 + coeffB Q * (v 0) * (v 1) + coeffC Q * (v 1) ^ 2 := by
+  let e0 : Fin 2 → ℤ := coordVec 1 0
+  let e1 : Fin 2 → ℤ := coordVec 0 1
+  have hv : v = v 0 • e0 + v 1 • e1 := by
+    ext i
+    fin_cases i <;> simp [e0, e1, coordVec]
+  rw [hv]
+  rw [QuadraticMap.map_add (fun w => Q w) (v 0 • e0) (v 1 • e1)]
+  rw [Q.map_smul, Q.map_smul]
+  rw [QuadraticMap.polar_smul_left, QuadraticMap.polar_smul_right]
+  simp [coeffA, coeffB, coeffC, e0, e1, coordVec, QuadraticMap.polar]
+  ring
+
+@[simp]
+theorem ofQuadraticForm_eval (Q : IntegralQuadraticForm) (x y : ℤ) :
+    (ofQuadraticForm Q).eval x y =
+      coeffA Q * x ^ 2 + coeffB Q * x * y + coeffC Q * y ^ 2 :=
+  rfl
+
+@[simp]
+theorem toQuadraticForm_ofQuadraticForm (Q : IntegralQuadraticForm) :
+    toQuadraticForm (ofQuadraticForm Q) = Q := by
+  apply QuadraticMap.ext
+  intro v
+  rw [toQuadraticForm_apply, ofQuadraticForm_eval, apply_eq_coeffs]
+
+/-- The equivalence between the coordinate model and mathlib quadratic forms over `ℤ²`. -/
+def equivQuadraticForm : BinaryQuadraticForm ≃ IntegralQuadraticForm where
+  toFun := toQuadraticForm
+  invFun := ofQuadraticForm
+  left_inv := ofQuadraticForm_toQuadraticForm
+  right_inv := toQuadraticForm_ofQuadraticForm
+
+@[simp]
+theorem classicalDisc_toQuadraticForm (Q : BinaryQuadraticForm) :
+    classicalDisc (toQuadraticForm Q) = Q.disc := by
+  simp [classicalDisc, disc]
+
+@[simp]
+theorem disc_ofQuadraticForm (Q : IntegralQuadraticForm) :
+    (ofQuadraticForm Q).disc = classicalDisc Q := by
+  simp [ofQuadraticForm, classicalDisc, disc]
+
+/-! ## Rational discriminant normalization -/
+
+/-- Matrix representing `Q` as a mathlib quadratic form over `ℚ`. -/
+def toRationalQuadraticFormMatrix (Q : BinaryQuadraticForm) : Matrix (Fin 2) (Fin 2) ℚ :=
+  !![(Q.a : ℚ), (Q.b : ℚ); 0, (Q.c : ℚ)]
+
+/-- Interpret a coordinate binary quadratic form as a rational mathlib quadratic form. -/
+def toRationalQuadraticForm (Q : BinaryQuadraticForm) : RationalQuadraticForm :=
+  (toRationalQuadraticFormMatrix Q).toQuadraticMap'
+
+/-- The rational bridge evaluates to the same polynomial with rational coefficients. -/
+theorem toRationalQuadraticForm_apply (Q : BinaryQuadraticForm) (x y : ℚ) :
+    Q.toRationalQuadraticForm (coordVec x y) =
+      (Q.a : ℚ) * x ^ 2 + (Q.b : ℚ) * x * y + (Q.c : ℚ) * y ^ 2 := by
+  rcases Q with ⟨a, b, c⟩
+  simp [toRationalQuadraticForm, toRationalQuadraticFormMatrix, coordVec,
+    Matrix.toQuadraticMap', LinearMap.BilinMap.toQuadraticMap_apply,
+    Matrix.toLinearMap₂'_apply', dotProduct, Matrix.mulVec]
+  ring_nf
+
+/-- The associated rational matrix has the classical half-cross-term shape. -/
+theorem toMatrix'_toRationalQuadraticForm (Q : BinaryQuadraticForm) :
+    Q.toRationalQuadraticForm.toMatrix' =
+      !![(Q.a : ℚ), (Q.b : ℚ) / 2; (Q.b : ℚ) / 2, (Q.c : ℚ)] := by
+  rcases Q with ⟨a, b, c⟩
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [toRationalQuadraticForm, toRationalQuadraticFormMatrix, QuadraticMap.toMatrix',
+      QuadraticMap.associated, QuadraticMap.associatedHom, LinearMap.toMatrix₂'_apply,
+      Matrix.toQuadraticMap', LinearMap.BilinMap.polar_toQuadraticMap,
+      LinearMap.BilinMap.toQuadraticMap_apply, Matrix.toLinearMap₂'_apply', dotProduct,
+      Matrix.mulVec] <;> ring_nf
+
+/-- Mathlib's rational matrix discriminant is `-1/4` times the classical discriminant. -/
+theorem discr_toRationalQuadraticForm (Q : BinaryQuadraticForm) :
+    -4 * QuadraticMap.discr Q.toRationalQuadraticForm = (Q.disc : ℚ) := by
+  rw [QuadraticMap.discr, toMatrix'_toRationalQuadraticForm]
+  rcases Q with ⟨a, b, c⟩
+  simp [Matrix.det_fin_two_of, disc]
+  ring_nf
+
+/-! ## Compatibility with the `SL₂(ℤ)` action -/
+
+/-- The linear map on `ℤ²` induced by an `SL₂(ℤ)` matrix. -/
+def linearMapOfSL2Z (g : SL2Z) : (Fin 2 → ℤ) →ₗ[ℤ] (Fin 2 → ℤ) where
+  toFun v :=
+    coordVec
+      ((g : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * v 0 +
+        (g : Matrix (Fin 2) (Fin 2) ℤ) 0 1 * v 1)
+      ((g : Matrix (Fin 2) (Fin 2) ℤ) 1 0 * v 0 +
+        (g : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * v 1)
+  map_add' v w := by
+    ext i
+    fin_cases i <;> simp [coordVec] <;> ring
+  map_smul' n v := by
+    ext i
+    fin_cases i <;> simp [coordVec] <;> ring
+
+@[simp]
+theorem linearMapOfSL2Z_apply (g : SL2Z) (v : Fin 2 → ℤ) :
+    linearMapOfSL2Z g v =
+      coordVec
+        ((g : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * v 0 +
+          (g : Matrix (Fin 2) (Fin 2) ℤ) 0 1 * v 1)
+        ((g : Matrix (Fin 2) (Fin 2) ℤ) 1 0 * v 0 +
+          (g : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * v 1) :=
+  rfl
+
+/-- The coordinate `SL₂(ℤ)` action is mathlib quadratic-form composition by the
+induced linear map on `ℤ²`. -/
+theorem toQuadraticForm_transform (Q : BinaryQuadraticForm) (g : SL2Z) :
+    toQuadraticForm (transform Q g) = (toQuadraticForm Q).comp (linearMapOfSL2Z g) := by
+  apply QuadraticMap.ext
+  intro v
+  simp [transform, eval, coordVec]
+  ring
+
+/-- Proper equivalence of coordinate forms gives equality after composing the
+associated mathlib quadratic form with the corresponding linear map. -/
+theorem exists_toQuadraticForm_eq_comp_of_properEquivalent {Q R : BinaryQuadraticForm}
+    (hQR : ProperEquivalent Q R) :
+    ∃ g : SL2Z, toQuadraticForm R = (toQuadraticForm Q).comp (linearMapOfSL2Z g) := by
+  rcases hQR with ⟨g, rfl⟩
+  exact ⟨g, toQuadraticForm_transform Q g⟩
+
+/-! ## Positive definiteness -/
+
+/-- Positive definite coordinate forms are positive definite as mathlib
+quadratic forms over `ℤ²`. -/
+theorem toQuadraticForm_posDef (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) : (toQuadraticForm Q).PosDef := by
+  intro v hv
+  rw [toQuadraticForm_apply]
+  apply eval_pos_of_isPositiveDefinite Q hQ
+  by_cases h0 : v 0 = 0
+  · by_cases h1 : v 1 = 0
+    · exfalso
+      apply hv
+      ext i
+      fin_cases i <;> simp [h0, h1]
+    · exact Or.inr h1
+  · exact Or.inl h0
+
+/-- If the attached mathlib quadratic form is positive definite, then the
+coordinate form is positive definite. -/
+theorem isPositiveDefinite_of_toQuadraticForm_posDef (Q : BinaryQuadraticForm)
+    (hQ : (toQuadraticForm Q).PosDef) : Q.IsPositiveDefinite := by
+  have h10_ne : (coordVec 1 0 : Fin 2 → ℤ) ≠ 0 := by
+    intro h
+    have := congr_fun h 0
+    norm_num [coordVec] at this
+  have ha : 0 < Q.a := by
+    have h := hQ (coordVec 1 0) h10_ne
+    simpa [toQuadraticForm_coordVec, eval, coordVec] using h
+  have hvec_ne : coordVec Q.b (-2 * Q.a) ≠ 0 := by
+    intro h
+    have h1 := congr_fun h 1
+    have : -2 * Q.a = 0 := by simpa [coordVec] using h1
+    nlinarith
+  have hval := hQ (coordVec Q.b (-2 * Q.a)) hvec_ne
+  have hcalc : Q.eval Q.b (-2 * Q.a) = -Q.a * Q.disc := by
+    simp [eval, disc]
+    ring_nf
+  rw [toQuadraticForm_coordVec, hcalc] at hval
+  exact ⟨ha, by nlinarith⟩
+
+/-- The project positivity predicate agrees with mathlib positive-definiteness. -/
+theorem toQuadraticForm_posDef_iff (Q : BinaryQuadraticForm) :
+    (toQuadraticForm Q).PosDef ↔ Q.IsPositiveDefinite :=
+  ⟨isPositiveDefinite_of_toQuadraticForm_posDef Q, toQuadraticForm_posDef Q⟩
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/QuadraticNumberFields.lean
+++ b/QuadraticNumberFields.lean
@@ -40,6 +40,9 @@ import QuadraticNumberFields.Splitting.Qsqrtd.Monogenic
 import QuadraticNumberFields.Splitting.Qsqrtd.OddPrime
 import QuadraticNumberFields.Splitting.Qsqrtd.Two
 import QuadraticNumberFields.Splitting.QuadraticField.Basic
+import BinaryQuadraticForms.Core.Basic
+import BinaryQuadraticForms.Core.Action
+import BinaryQuadraticForms.Core.QuadraticFormBridge
 import QuadraticNumberFields.ClassNumber
 import QuadraticNumberFields.Examples.SqrtNeg5.Ideals
 import QuadraticNumberFields.Examples.SqrtNeg5.RamificationInertia

--- a/QuadraticNumberFields.lean
+++ b/QuadraticNumberFields.lean
@@ -42,6 +42,7 @@ import QuadraticNumberFields.Splitting.Qsqrtd.Two
 import QuadraticNumberFields.Splitting.QuadraticField.Basic
 import BinaryQuadraticForms.Core.Basic
 import BinaryQuadraticForms.Core.Action
+import BinaryQuadraticForms.Core.Class
 import BinaryQuadraticForms.Core.QuadraticFormBridge
 import QuadraticNumberFields.ClassNumber
 import QuadraticNumberFields.Examples.SqrtNeg5.Ideals

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,7 +1,7 @@
 name = "QuadraticNumberFields"
 version = "0.1.0"
 keywords = ["math", "number-theory", "quadratic-fields"]
-defaultTargets = ["QNFMathlib", "QuadraticNumberFields"]
+defaultTargets = ["QNFMathlib", "BinaryQuadraticForms", "QuadraticNumberFields"]
 lintDriver = "runLinter"
 
 [leanOptions]

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -28,6 +28,9 @@ git = "https://github.com/PatrickMassot/checkdecls.git"
 name = "QNFMathlib"
 
 [[lean_lib]]
+name = "BinaryQuadraticForms"
+
+[[lean_lib]]
 name = "QuadraticNumberFields"
 
 [[lean_exe]]


### PR DESCRIPTION
## Summary

- Add the standalone `BinaryQuadraticForms` Lean library root.
- Introduce the computable integral binary-quadratic-form coordinate model, SL2 action, proper equivalence class API, and bridge to mathlib `QuadraticForm`.
- Re-export the core BQF modules from `QuadraticNumberFields.lean`.

## Stack

This is stack PR 1 after #49. Next branch: `bqf-reduction-enumeration`.

## Verification

- `git diff --check`
- `lake build BinaryQuadraticForms`
- `lake build`