### PR TITLE
Add reduced-form enumeration for binary quadratic forms

### DIFF
--- a/BinaryQuadraticForms.lean
+++ b/BinaryQuadraticForms.lean
@@ -7,7 +7,12 @@ Authors: Frankie Wang
 import BinaryQuadraticForms.Core.Action
 import BinaryQuadraticForms.Core.Basic
 import BinaryQuadraticForms.Core.Class
+import BinaryQuadraticForms.Core.ClassReduced
+import BinaryQuadraticForms.Core.Enumeration
 import BinaryQuadraticForms.Core.QuadraticFormBridge
+import BinaryQuadraticForms.Core.ReducedUniqueness
+import BinaryQuadraticForms.Core.Reduction
+import BinaryQuadraticForms.Core.UpperHalfPlane
 
 /-!
 # Binary Quadratic Forms

--- a/BinaryQuadraticForms/Core/ClassReduced.lean
+++ b/BinaryQuadraticForms/Core/ClassReduced.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.Class
+import BinaryQuadraticForms.Core.ReducedUniqueness
+
+/-!
+# Reduced Representatives of Form Classes
+
+This file connects the primitive positive definite form-class carrier to the
+Gauss reduction existence and uniqueness theorems.
+-/
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+/-! ## Restricted Gauss reduction interface -/
+
+/-- Every primitive positive definite form has a properly equivalent reduced
+representative inside the same restricted carrier. -/
+theorem exists_isReduced_primitivePositiveDefiniteForm_properEquivalent
+    {D : ℤ} (Q : PrimitivePositiveDefiniteForm D) :
+    ∃ R : PrimitivePositiveDefiniteForm D, R.1.IsReduced ∧
+      PrimitivePositiveDefiniteForm.ProperEquivalent Q R := by
+  obtain ⟨R, hRred, hQR⟩ := exists_isReduced_properEquivalent Q.1 Q.2.2.2
+  rcases hQR with ⟨g, rfl⟩
+  refine ⟨⟨transform Q.1 g, ?_⟩, hRred, ⟨g, rfl⟩⟩
+  constructor
+  · exact (disc_transform Q.1 g).trans Q.2.1
+  · constructor
+    · exact isPrimitive_transform Q.1 Q.2.2.1 g
+    · exact isPositiveDefinite_transform Q.1 Q.2.2.2 g
+
+/-- Boundary-normalized reduced representatives are unique within the
+restricted primitive positive definite carrier. -/
+theorem eq_of_isReduced_primitivePositiveDefiniteForm_of_properEquivalent
+    {D : ℤ} {Q R : PrimitivePositiveDefiniteForm D}
+    (hQred : Q.1.IsReduced) (hRred : R.1.IsReduced)
+    (h : PrimitivePositiveDefiniteForm.ProperEquivalent Q R) : Q = R := by
+  apply Subtype.ext
+  exact eq_of_isReduced_of_properEquivalent Q.2.2.2 hQred hRred h
+
+/-- Every form class has a reduced primitive positive definite representative. -/
+theorem exists_isReduced_mk_eq_formClass {D : ℤ} (C : FormClass D) :
+    ∃ R : PrimitivePositiveDefiniteForm D, R.1.IsReduced ∧
+      Quotient.mk (primitivePositiveDefiniteFormSetoid D) R = C := by
+  induction C using Quotient.inductionOn with
+  | h Q =>
+      obtain ⟨R, hRred, hQR⟩ :=
+        exists_isReduced_primitivePositiveDefiniteForm_properEquivalent Q
+      exact ⟨R, hRred, (Quotient.sound hQR).symm⟩
+
+/-- Reduced representatives of the same form class are equal. -/
+theorem eq_of_isReduced_of_mk_eq_mk {D : ℤ} {Q R : PrimitivePositiveDefiniteForm D}
+    (hQred : Q.1.IsReduced) (hRred : R.1.IsReduced)
+    (hclass : Quotient.mk (primitivePositiveDefiniteFormSetoid D) Q =
+      Quotient.mk (primitivePositiveDefiniteFormSetoid D) R) :
+    Q = R :=
+  eq_of_isReduced_primitivePositiveDefiniteForm_of_properEquivalent hQred hRred
+    (Quotient.exact hclass)
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/BinaryQuadraticForms/Core/Enumeration.lean
+++ b/BinaryQuadraticForms/Core/Enumeration.lean
@@ -1,0 +1,342 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.ClassReduced
+import BinaryQuadraticForms.Core.Reduction
+import Mathlib.Data.Nat.Sqrt
+import Mathlib.Tactic
+
+/-!
+# Enumeration of Reduced Binary Quadratic Forms
+
+This file defines a computable search space for primitive reduced positive
+definite forms of a negative discriminant.
+-/
+
+/-- Close concrete reduced-form list cardinality goals by executable enumeration. -/
+syntax "reduce_forms_count" : tactic
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+instance decidableHasDiscriminant (Q : BinaryQuadraticForm) (D : ℤ) :
+    Decidable (Q.HasDiscriminant D) := by
+  unfold HasDiscriminant
+  infer_instance
+
+instance decidableIsPositiveDefinite (Q : BinaryQuadraticForm) :
+    Decidable Q.IsPositiveDefinite := by
+  unfold IsPositiveDefinite
+  infer_instance
+
+instance decidableIsReduced (Q : BinaryQuadraticForm) :
+    Decidable Q.IsReduced := by
+  unfold IsReduced
+  infer_instance
+
+instance decidableIsPrimitive (Q : BinaryQuadraticForm) :
+    Decidable Q.IsPrimitive := by
+  unfold IsPrimitive
+  infer_instance
+
+/-- A simple computable search bound for reduced forms. -/
+def searchBound (D : ℤ) : ℕ :=
+  Nat.sqrt D.natAbs + 1
+
+/-- A reduced positive definite form has its `a` coefficient within the
+enumeration search bound. -/
+theorem a_natAbs_le_searchBound (Q : BinaryQuadraticForm)
+    (hpos : Q.IsPositiveDefinite) (hred : Q.IsReduced) :
+    Q.a.natAbs ≤ searchBound Q.disc := by
+  have hbound := three_mul_a_natAbs_sq_le_disc_natAbs Q hpos hred
+  have hsq : Q.a.natAbs ^ 2 ≤ Q.disc.natAbs := by
+    nlinarith
+  exact (Nat.le_sqrt'.mpr hsq).trans (Nat.le_succ _)
+
+/-- Positive `a` candidates up to the search bound. -/
+def aCandidates (D : ℤ) : List ℕ :=
+  (List.range (searchBound D + 1)).filter fun a => 0 < a
+
+/-- The `a`-candidate list has no duplicates. -/
+theorem aCandidates_nodup (D : ℤ) : (aCandidates D).Nodup :=
+  List.Nodup.filter _ List.nodup_range
+
+/-- Integer `b` candidates in `[-a, a]`, generated computably from naturals. -/
+def bCandidates (a : ℕ) : List ℤ :=
+  (List.range (2 * a + 1)).map fun k : ℕ => (k : ℤ) - (a : ℤ)
+
+/-- The `b`-candidate list has no duplicates. -/
+theorem bCandidates_nodup (a : ℕ) : (bCandidates a).Nodup := by
+  refine List.Nodup.map ?_ List.nodup_range
+  intro k l hkl
+  change (k : ℤ) - (a : ℤ) = (l : ℤ) - (a : ℤ) at hkl
+  have h : (k : ℤ) = l := by omega
+  exact_mod_cast h
+
+private def candidateFormsForA (D : ℤ) (a : ℕ) : List BinaryQuadraticForm :=
+  (bCandidates a).map fun b : ℤ =>
+    BinaryQuadraticForm.mk (a : ℤ) b ((b ^ 2 - D) / (4 * (a : ℤ)))
+
+/-- Candidate triples before the reduced/primitive filters. -/
+def candidateForms (D : ℤ) : List BinaryQuadraticForm :=
+  (aCandidates D).flatMap (candidateFormsForA D)
+
+private theorem candidateFormsForA_nodup (D : ℤ) (a : ℕ) :
+    (candidateFormsForA D a).Nodup := by
+  unfold candidateFormsForA
+  refine List.Nodup.map ?_ (bCandidates_nodup a)
+  intro b c hbc
+  exact congrArg BinaryQuadraticForm.b hbc
+
+private theorem candidateFormsForA_disjoint_of_ne {D : ℤ} {a b : ℕ} (hab : a ≠ b) :
+    List.Disjoint (candidateFormsForA D a) (candidateFormsForA D b) := by
+  rw [List.disjoint_iff_ne]
+  intro Q hQ R hR hQR
+  unfold candidateFormsForA at hQ hR
+  rw [List.mem_map] at hQ hR
+  rcases hQ with ⟨m, _hm, hQeq⟩
+  rcases hR with ⟨n, _hn, hReq⟩
+  have hab' : (a : ℤ) = b := by
+    simpa [← hQeq, ← hReq] using congrArg BinaryQuadraticForm.a hQR
+  exact hab (by exact_mod_cast hab')
+
+private theorem aCandidates_pairwise_candidateFormsForA_disjoint (D : ℤ) :
+    List.Pairwise (Function.onFun List.Disjoint (candidateFormsForA D)) (aCandidates D) := by
+  change List.Pairwise (fun a b => List.Disjoint (candidateFormsForA D a)
+    (candidateFormsForA D b)) (aCandidates D)
+  exact List.Pairwise.imp (fun hab => candidateFormsForA_disjoint_of_ne hab)
+    (aCandidates_nodup D)
+
+/-- Raw candidate triples are generated without duplicates. -/
+theorem candidateForms_nodup (D : ℤ) : (candidateForms D).Nodup := by
+  rw [candidateForms, List.nodup_flatMap]
+  exact ⟨fun a _ha => candidateFormsForA_nodup D a,
+    aCandidates_pairwise_candidateFormsForA_disjoint D⟩
+
+/-- Primitive reduced positive definite forms of discriminant `D`. -/
+def enumPrimitiveReducedFormsList (D : ℤ) : List BinaryQuadraticForm :=
+  (candidateForms D).filter fun Q =>
+    Q.HasDiscriminant D ∧ Q.IsPositiveDefinite ∧ Q.IsReduced ∧ Q.IsPrimitive
+
+/-- Finset view of primitive reduced positive definite forms of discriminant `D`. -/
+def enumPrimitiveReducedForms (D : ℤ) : Finset BinaryQuadraticForm :=
+  (enumPrimitiveReducedFormsList D).toFinset
+
+/-- Every list-enumerated form satisfies the filter predicates. -/
+theorem of_mem_enumPrimitiveReducedFormsList {D : ℤ} {Q : BinaryQuadraticForm}
+    (hQ : Q ∈ enumPrimitiveReducedFormsList D) :
+    Q.HasDiscriminant D ∧ Q.IsPositiveDefinite ∧ Q.IsReduced ∧ Q.IsPrimitive := by
+  have hfilter : Q ∈ candidateForms D ∧
+      Q.HasDiscriminant D ∧ Q.IsPositiveDefinite ∧ Q.IsReduced ∧ Q.IsPrimitive := by
+    simpa [enumPrimitiveReducedFormsList] using hQ
+  exact hfilter.2
+
+/-- Every finset-enumerated form satisfies the filter predicates. -/
+theorem of_mem_enumPrimitiveReducedForms {D : ℤ} {Q : BinaryQuadraticForm}
+    (hQ : Q ∈ enumPrimitiveReducedForms D) :
+    Q.HasDiscriminant D ∧ Q.IsPositiveDefinite ∧ Q.IsReduced ∧ Q.IsPrimitive := by
+  apply of_mem_enumPrimitiveReducedFormsList
+  simpa [enumPrimitiveReducedForms] using hQ
+
+/-- The positive `a` coefficient of a reduced positive definite form lies in the
+`a`-candidate list of its discriminant. -/
+theorem a_mem_aCandidates_of_reduced {D : ℤ} {Q : BinaryQuadraticForm}
+    (hdisc : Q.HasDiscriminant D) (hpos : Q.IsPositiveDefinite)
+    (hred : Q.IsReduced) :
+    Q.a.natAbs ∈ aCandidates D := by
+  have hle : Q.a.natAbs ≤ searchBound D := by
+    have h := a_natAbs_le_searchBound Q hpos hred
+    have hd : Q.disc = D := hdisc
+    rwa [hd] at h
+  have hpos' : 0 < Q.a.natAbs := Int.natAbs_pos.mpr (ne_of_gt hpos.1)
+  simp only [aCandidates, List.mem_filter, List.mem_range, decide_eq_true_eq]
+  omega
+
+/-- The `b` coefficient of a reduced positive definite form lies in the
+`b`-candidate list determined by the reduced bound `|b| ≤ a`. -/
+theorem b_mem_bCandidates_of_reduced {Q : BinaryQuadraticForm}
+    (hpos : Q.IsPositiveDefinite) (hred : Q.IsReduced) :
+    Q.b ∈ bCandidates Q.a.natAbs := by
+  have habs := abs_le.mp hred.1
+  have ha : 0 < Q.a := hpos.1
+  simp only [bCandidates, List.mem_map, List.mem_range]
+  exact ⟨(Q.b + Q.a.natAbs).toNat, by omega, by omega⟩
+
+/-- A reduced positive definite form of discriminant `D` occurs among the raw
+candidate triples, with `c` recovered as `(b² - D) / (4a)`. -/
+theorem mem_candidateForms_of_reduced {D : ℤ} {Q : BinaryQuadraticForm}
+    (hdisc : Q.HasDiscriminant D) (hpos : Q.IsPositiveDefinite)
+    (hred : Q.IsReduced) :
+    Q ∈ candidateForms D := by
+  have hacast : (Q.a.natAbs : ℤ) = Q.a := Int.natAbs_of_nonneg (le_of_lt hpos.1)
+  have hdiscD : Q.b ^ 2 - 4 * Q.a * Q.c = D := hdisc
+  have h4a : (4 : ℤ) * Q.a ≠ 0 := by have := hpos.1; omega
+  have hcrec : (Q.b ^ 2 - D) / (4 * (Q.a.natAbs : ℤ)) = Q.c := by
+    rw [hacast, ← hdiscD,
+      show Q.b ^ 2 - (Q.b ^ 2 - 4 * Q.a * Q.c) = 4 * Q.a * Q.c from by ring]
+    exact Int.mul_ediv_cancel_left Q.c h4a
+  unfold candidateForms
+  exact List.mem_flatMap.mpr ⟨Q.a.natAbs, a_mem_aCandidates_of_reduced hdisc hpos hred,
+    List.mem_map.mpr ⟨Q.b, b_mem_bCandidates_of_reduced hpos hred,
+      BinaryQuadraticForm.ext hacast rfl hcrec⟩⟩
+
+/-- **Completeness of the reduced-form enumeration.** Every primitive reduced
+positive definite form of discriminant `D` appears in `enumPrimitiveReducedForms D`.
+Together with `of_mem_enumPrimitiveReducedForms` this characterizes the
+enumeration exactly. -/
+theorem mem_enumPrimitiveReducedForms_of_reduced {D : ℤ} {Q : BinaryQuadraticForm}
+    (hdisc : Q.HasDiscriminant D) (hpos : Q.IsPositiveDefinite)
+    (hred : Q.IsReduced) (hprim : Q.IsPrimitive) :
+    Q ∈ enumPrimitiveReducedForms D := by
+  simp only [enumPrimitiveReducedForms, List.mem_toFinset, enumPrimitiveReducedFormsList,
+    List.mem_filter, decide_eq_true_eq]
+  exact ⟨mem_candidateForms_of_reduced hdisc hpos hred, hdisc, hpos, hred, hprim⟩
+
+/-- Membership in the finset enumeration is exactly the conjunction of the
+filtered reduced-form predicates. -/
+theorem mem_enumPrimitiveReducedForms_iff {D : ℤ} {Q : BinaryQuadraticForm} :
+    Q ∈ enumPrimitiveReducedForms D ↔
+      Q.HasDiscriminant D ∧ Q.IsPositiveDefinite ∧ Q.IsReduced ∧ Q.IsPrimitive := by
+  constructor
+  · exact of_mem_enumPrimitiveReducedForms
+  · intro hQ
+    exact mem_enumPrimitiveReducedForms_of_reduced hQ.1 hQ.2.1 hQ.2.2.1 hQ.2.2.2
+
+/-- View an enumerated reduced primitive positive definite form as a member of
+the restricted Cox carrier. -/
+def primitivePositiveDefiniteFormOfMemEnum {D : ℤ} {Q : BinaryQuadraticForm}
+    (hQ : Q ∈ enumPrimitiveReducedForms D) : PrimitivePositiveDefiniteForm D :=
+  let h := of_mem_enumPrimitiveReducedForms hQ
+  ⟨Q, h.1, h.2.2.2, h.2.1⟩
+
+/-- Form classes represented by the reduced-form enumeration. -/
+noncomputable def reducedFormClasses (D : ℤ) : Finset (FormClass D) := by
+  classical
+  exact (enumPrimitiveReducedForms D).attach.image fun Q =>
+    Quotient.mk (primitivePositiveDefiniteFormSetoid D)
+      (primitivePositiveDefiniteFormOfMemEnum Q.2)
+
+/-- Every form class has a representative in the reduced-form enumeration. -/
+theorem mem_reducedFormClasses (D : ℤ) (C : FormClass D) : C ∈ reducedFormClasses D := by
+  classical
+  obtain ⟨R, hRred, hRclass⟩ := exists_isReduced_mk_eq_formClass C
+  have hRmem : R.1 ∈ enumPrimitiveReducedForms D :=
+    mem_enumPrimitiveReducedForms_of_reduced R.2.1 R.2.2.2 hRred R.2.2.1
+  refine Finset.mem_image.mpr ⟨⟨R.1, hRmem⟩, ?_, ?_⟩
+  · simp
+  · simpa [primitivePositiveDefiniteFormOfMemEnum] using hRclass
+
+noncomputable instance formClassFintype (D : ℤ) : Fintype (FormClass D) :=
+  ⟨reducedFormClasses D, mem_reducedFormClasses D⟩
+
+/-- The reduced-form representatives cover all form classes. -/
+theorem reducedFormClasses_eq_univ (D : ℤ) : reducedFormClasses D = Finset.univ := by
+  classical
+  ext C
+  exact ⟨fun _ => Finset.mem_univ C, fun _ => mem_reducedFormClasses D C⟩
+
+/-- Passing from reduced forms to form classes does not identify distinct
+enumerated forms. -/
+theorem reducedFormClasses_card (D : ℤ) :
+    (reducedFormClasses D).card = (enumPrimitiveReducedForms D).card := by
+  classical
+  rw [reducedFormClasses]
+  trans (enumPrimitiveReducedForms D).attach.card
+  · refine Finset.card_image_of_injective _ ?_
+    intro Q R hQR
+    have hQ := of_mem_enumPrimitiveReducedForms Q.2
+    have hR := of_mem_enumPrimitiveReducedForms R.2
+    have hclass :
+        Quotient.mk (primitivePositiveDefiniteFormSetoid D)
+          (primitivePositiveDefiniteFormOfMemEnum Q.2) =
+        Quotient.mk (primitivePositiveDefiniteFormSetoid D)
+          (primitivePositiveDefiniteFormOfMemEnum R.2) := by
+      simpa using hQR
+    have hval : Q.1 = R.1 :=
+      congrArg (fun S : PrimitivePositiveDefiniteForm D => S.1)
+        (eq_of_isReduced_of_mk_eq_mk hQ.2.2.1 hR.2.2.1 hclass)
+    exact Subtype.ext hval
+  · simp
+
+/-- The list view of the reduced-form enumeration has no duplicates. -/
+theorem enumPrimitiveReducedFormsList_nodup (D : ℤ) :
+    (enumPrimitiveReducedFormsList D).Nodup := by
+  simpa [enumPrimitiveReducedFormsList] using
+    (candidateForms_nodup D).filter (fun Q =>
+      Q.HasDiscriminant D ∧ Q.IsPositiveDefinite ∧ Q.IsReduced ∧ Q.IsPrimitive)
+
+/-- The finset cardinality agrees with the list length because the list
+enumerator is duplicate-free. -/
+theorem enumPrimitiveReducedForms_card_eq_length (D : ℤ) :
+    (enumPrimitiveReducedForms D).card = (enumPrimitiveReducedFormsList D).length := by
+  simpa [enumPrimitiveReducedForms] using
+    List.toFinset_card_of_nodup (enumPrimitiveReducedFormsList_nodup D)
+
+macro_rules
+  | `(tactic| reduce_forms_count) =>
+      `(tactic|
+        norm_num [enumPrimitiveReducedFormsList, candidateForms, candidateFormsForA,
+          aCandidates, searchBound, bCandidates] <;> decide)
+
+/-- The reduced primitive positive definite forms of discriminant `-20` are two. -/
+theorem enumPrimitiveReducedFormsList_neg20_length :
+    (enumPrimitiveReducedFormsList (-20)).length = 2 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-4` are one. -/
+theorem enumPrimitiveReducedFormsList_neg4_length :
+    (enumPrimitiveReducedFormsList (-4)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-8` are one. -/
+theorem enumPrimitiveReducedFormsList_neg8_length :
+    (enumPrimitiveReducedFormsList (-8)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-3` are one. -/
+theorem enumPrimitiveReducedFormsList_neg3_length :
+    (enumPrimitiveReducedFormsList (-3)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-7` are one. -/
+theorem enumPrimitiveReducedFormsList_neg7_length :
+    (enumPrimitiveReducedFormsList (-7)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-11` are one. -/
+theorem enumPrimitiveReducedFormsList_neg11_length :
+    (enumPrimitiveReducedFormsList (-11)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-19` are one. -/
+theorem enumPrimitiveReducedFormsList_neg19_length :
+    (enumPrimitiveReducedFormsList (-19)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-43` are one. -/
+theorem enumPrimitiveReducedFormsList_neg43_length :
+    (enumPrimitiveReducedFormsList (-43)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-67` are one. -/
+theorem enumPrimitiveReducedFormsList_neg67_length :
+    (enumPrimitiveReducedFormsList (-67)).length = 1 := by
+  reduce_forms_count
+
+/-- The reduced primitive positive definite forms of discriminant `-163` are one. -/
+theorem enumPrimitiveReducedFormsList_neg163_length :
+    (enumPrimitiveReducedFormsList (-163)).length = 1 := by
+  reduce_forms_count
+
+example : bCandidates 1 = [-1, 0, 1] := by
+  decide
+
+-- Smoke checks used during development:
+-- `#guard (enumPrimitiveReducedFormsList (-20)).length == 2`
+-- `#guard (enumPrimitiveReducedFormsList (-163)).length == 1`
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/BinaryQuadraticForms/Core/ReducedUniqueness.lean
+++ b/BinaryQuadraticForms/Core/ReducedUniqueness.lean
@@ -1,0 +1,354 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.UpperHalfPlane
+
+/-!
+# Uniqueness of Reduced Representatives
+
+This module proves the Gauss-reduction half of the Cox 7.7 bridge: every
+positive definite binary quadratic form is properly equivalent to a reduced
+form (`exists_isReduced_properEquivalent`), and the boundary-normalized reduced
+representative of a proper-equivalence class is unique
+(`eq_of_isReduced_of_properEquivalent`).
+
+The argument runs through the upper-half-plane root `tauOfForm`: reduction is the
+statement that the root lies in the modular fundamental domain `ModularGroup.fd`,
+and uniqueness is a case analysis on the `SL₂(ℤ)` elements that fix the
+fundamental domain (the identity, `S`, `T`, and the stabilizers of `ρ`).
+
+These results are consumed by `Forms.Core.ClassReduced` and the Cox bridge to
+choose reduced representatives of `FormClass`.
+-/
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+/-- Gauss reduction existence statement for positive definite forms. -/
+theorem exists_isReduced_properEquivalent (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) : ∃ R, R.IsReduced ∧ ProperEquivalent Q R := by
+  obtain ⟨g, hgfd⟩ := ModularGroup.exists_smul_mem_fd (tauOfForm Q hQ)
+  let P := transform Q g⁻¹
+  have hPpos : P.IsPositiveDefinite := isPositiveDefinite_transform Q hQ g⁻¹
+  have hτP : tauOfForm P hPpos = g • tauOfForm Q hQ := by
+    simpa [P] using tauOfForm_transform Q hQ g⁻¹ hPpos
+  have hPfd : tauOfForm P hPpos ∈ ModularGroup.fd := by
+    simpa [hτP] using hgfd
+  obtain ⟨n, hnred⟩ := exists_isReduced_transform_of_mem_fd P hPpos hPfd
+  refine ⟨transform P n, hnred, ?_⟩
+  refine ⟨g⁻¹ * n, ?_⟩
+  simpa [P] using (transform_mul Q g⁻¹ n).symm
+
+private theorem transform_neg (Q : BinaryQuadraticForm) (g : SL2Z) :
+    transform Q (-g) = transform Q g := by
+  ext <;> simp only [transform_a, transform_b, transform_c,
+    Matrix.SpecialLinearGroup.coe_neg, Matrix.neg_apply] <;> ring
+
+private theorem transform_neg_one (Q : BinaryQuadraticForm) :
+    transform Q (-1 : SL2Z) = Q := by
+  simpa using transform_neg Q (1 : SL2Z)
+
+private theorem transform_T_inv_mk (a b c : ℤ) :
+    transform (BinaryQuadraticForm.mk a b c) (ModularGroup.T⁻¹ : SL2Z) =
+      BinaryQuadraticForm.mk a (b - 2 * a) (a - b + c) := by
+  ext <;> simp only [transform_a, transform_b, transform_c] <;>
+    norm_num [ModularGroup.T, Matrix.SpecialLinearGroup.coe_inv, Matrix.adjugate_fin_two] <;>
+    ring
+
+private theorem transform_S_mk (a b c : ℤ) :
+    transform (BinaryQuadraticForm.mk a b c) ModularGroup.S =
+      BinaryQuadraticForm.mk c (-b) a := by
+  ext <;> simp only [transform_a, transform_b, transform_c] <;>
+    simp [ModularGroup.coe_S]
+
+private theorem transform_ST_self_of_mk_eq (a : ℤ) :
+    transform (BinaryQuadraticForm.mk a a a) (ModularGroup.S * ModularGroup.T : SL2Z) =
+      BinaryQuadraticForm.mk a a a := by
+  ext <;> simp only [transform_a, transform_b, transform_c] <;>
+    simp [ModularGroup.coe_S, ModularGroup.coe_T, Matrix.mul_apply, Fin.sum_univ_two]
+  all_goals ring
+
+private theorem transform_T_inv_S_self_of_mk_eq (a : ℤ) :
+    transform (BinaryQuadraticForm.mk a a a) (ModularGroup.T⁻¹ * ModularGroup.S : SL2Z) =
+      BinaryQuadraticForm.mk a a a := by
+  ext <;> simp only [transform_a, transform_b, transform_c] <;>
+    norm_num [ModularGroup.S, ModularGroup.T, Matrix.SpecialLinearGroup.coe_inv,
+      Matrix.adjugate_fin_two, Matrix.mul_apply, Fin.sum_univ_two]
+  all_goals ring
+
+private theorem transform_ST_inv_self_of_mk_eq (a : ℤ) :
+    transform (BinaryQuadraticForm.mk a a a) ((ModularGroup.S * ModularGroup.T : SL2Z)⁻¹) =
+      BinaryQuadraticForm.mk a a a := by
+  ext <;> simp only [transform_a, transform_b, transform_c] <;>
+    norm_num [ModularGroup.S, ModularGroup.T, Matrix.SpecialLinearGroup.coe_inv,
+      Matrix.adjugate_fin_two, Matrix.mul_apply, Fin.sum_univ_two]
+  all_goals ring
+
+private theorem transform_T_inv_S_inv_self_of_mk_eq (a : ℤ) :
+    transform (BinaryQuadraticForm.mk a a a) ((ModularGroup.T⁻¹ * ModularGroup.S : SL2Z)⁻¹) =
+      BinaryQuadraticForm.mk a a a := by
+  ext <;> simp only [transform_a, transform_b, transform_c] <;>
+    norm_num [ModularGroup.S, ModularGroup.T, Matrix.SpecialLinearGroup.coe_inv,
+      Matrix.adjugate_fin_two, Matrix.mul_apply, Fin.sum_univ_two]
+  all_goals ring
+
+private theorem transform_TST_inv_mk_eq (a : ℤ) :
+    transform (BinaryQuadraticForm.mk a a a)
+        ((ModularGroup.T * ModularGroup.S * ModularGroup.T : SL2Z)⁻¹) =
+      BinaryQuadraticForm.mk a (-a) a := by
+  ext <;> simp only [transform_a, transform_b, transform_c] <;>
+    simp [ModularGroup.coe_S, ModularGroup.coe_T, Matrix.mul_apply, Fin.sum_univ_two]
+  all_goals ring
+
+private theorem b_eq_a_of_tauOfForm_re_eq_neg_half (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (h : (tauOfForm Q hQ).re = -(1 : ℝ) / 2) :
+    Q.b = Q.a := by
+  have ha : (Q.a : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have hreal : -(Q.b : ℝ) / (2 * (Q.a : ℝ)) = -(1 : ℝ) / 2 := by
+    simpa [tauOfForm_re] using h
+  field_simp [ha] at hreal
+  have hba : (Q.b : ℝ) = Q.a := by nlinarith
+  exact_mod_cast hba
+
+private theorem b_eq_neg_a_of_tauOfForm_re_eq_half (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (h : (tauOfForm Q hQ).re = (1 : ℝ) / 2) :
+    Q.b = -Q.a := by
+  have ha : (Q.a : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have hreal : -(Q.b : ℝ) / (2 * (Q.a : ℝ)) = (1 : ℝ) / 2 := by
+    simpa [tauOfForm_re] using h
+  field_simp [ha] at hreal
+  have hba : (Q.b : ℝ) = -Q.a := by nlinarith
+  exact_mod_cast hba
+
+private theorem a_eq_c_of_tauOfForm_norm_eq_one (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (h : ‖(tauOfForm Q hQ : ℂ)‖ = 1) :
+    Q.a = Q.c := by
+  have ha : (Q.a : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have hnormSq : Complex.normSq (tauOfForm Q hQ : ℂ) = 1 := by
+    rw [Complex.normSq_eq_norm_sq, h]
+    norm_num
+  rw [normSq_tauOfForm] at hnormSq
+  field_simp [ha] at hnormSq
+  have hac : (Q.c : ℝ) = Q.a := by linarith
+  exact_mod_cast hac.symm
+
+private theorem b_eq_a_of_tauOfForm_eq_rho (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (h : tauOfForm Q hQ = UpperHalfPlane.ρ) :
+    Q.b = Q.a := by
+  apply b_eq_a_of_tauOfForm_re_eq_neg_half Q hQ
+  rw [h]
+  norm_num [UpperHalfPlane.ρ]
+
+private theorem b_eq_neg_a_of_tauOfForm_eq_one_vadd_rho (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (h : tauOfForm Q hQ = (1 : ℝ) +ᵥ UpperHalfPlane.ρ) :
+    Q.b = -Q.a := by
+  apply b_eq_neg_a_of_tauOfForm_re_eq_half Q hQ
+  rw [h]
+  norm_num [UpperHalfPlane.ρ]
+
+private theorem a_eq_c_of_tauOfForm_eq_rho (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (h : tauOfForm Q hQ = UpperHalfPlane.ρ) :
+    Q.a = Q.c := by
+  have ha : (Q.a : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have hnormSq : Complex.normSq (tauOfForm Q hQ : ℂ) = 1 := by
+    rw [h]
+    have hsqrt : Real.sqrt 3 * Real.sqrt 3 = (3 : ℝ) :=
+      Real.mul_self_sqrt (by norm_num)
+    norm_num [UpperHalfPlane.ρ, Complex.normSq_apply]
+    nlinarith
+  rw [normSq_tauOfForm] at hnormSq
+  field_simp [ha] at hnormSq
+  have hac : (Q.c : ℝ) = Q.a := by linarith
+  exact_mod_cast hac.symm
+
+private theorem false_of_isReduced_of_b_eq_neg_a (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hred : Q.IsReduced) (hb : Q.b = -Q.a) : False := by
+  rcases Q with ⟨a, b, c⟩
+  change 0 < a ∧ _ at hQ
+  change b = -a at hb
+  subst b
+  have hboundary : |-a| = a := by rw [abs_neg, abs_of_pos hQ.1]
+  have hnonneg := hred.2.2.1 hboundary
+  nlinarith
+
+private theorem false_of_isReduced_transform_T_inv_of_b_eq_a (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hb : Q.b = Q.a)
+    (hred : (transform Q (ModularGroup.T⁻¹ : SL2Z)).IsReduced) : False := by
+  rcases Q with ⟨a, b, c⟩
+  change 0 < a ∧ _ at hQ
+  change b = a at hb
+  subst b
+  rw [transform_T_inv_mk, isReduced_mk_iff] at hred
+  have hboundary : |a - 2 * a| = a := by
+    rw [show a - 2 * a = -a by ring, abs_neg, abs_of_pos hQ.1]
+  have hnonneg := hred.2.2.1 hboundary
+  nlinarith
+
+private theorem transform_S_eq_self_of_reduced_of_norm_eq_one (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hQred : Q.IsReduced)
+    (hSred : (transform Q ModularGroup.S).IsReduced)
+    (hnorm : ‖(tauOfForm Q hQ : ℂ)‖ = 1) :
+    transform Q ModularGroup.S = Q := by
+  have hac := a_eq_c_of_tauOfForm_norm_eq_one Q hQ hnorm
+  rcases Q with ⟨a, b, c⟩
+  change a = c at hac
+  subst c
+  have hb_nonneg : 0 ≤ b := hQred.2.2.2 rfl
+  rw [transform_S_mk, isReduced_mk_iff] at hSred
+  have hneg_nonneg : 0 ≤ -b := hSred.2.2.2 rfl
+  have hb_zero : b = 0 := by nlinarith
+  rw [transform_S_mk, hb_zero, neg_zero]
+
+private theorem false_of_isReduced_transform_TST_inv_of_tau_eq_rho (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hrho : tauOfForm Q hQ = UpperHalfPlane.ρ)
+    (hred :
+      (transform Q ((ModularGroup.T * ModularGroup.S * ModularGroup.T : SL2Z)⁻¹)).IsReduced) :
+    False := by
+  have hb := b_eq_a_of_tauOfForm_eq_rho Q hQ hrho
+  have hac := a_eq_c_of_tauOfForm_eq_rho Q hQ hrho
+  rcases Q with ⟨a, b, c⟩
+  change 0 < a ∧ _ at hQ
+  change b = a at hb
+  change a = c at hac
+  subst b
+  subst c
+  rw [transform_TST_inv_mk_eq, isReduced_mk_iff] at hred
+  have hboundary : |-a| = a := by rw [abs_neg, abs_of_pos hQ.1]
+  have hnonneg := hred.2.2.1 hboundary
+  nlinarith
+
+private theorem transform_ST_inv_eq_self_of_tau_eq_rho (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hrho : tauOfForm Q hQ = UpperHalfPlane.ρ) :
+    transform Q ((ModularGroup.S * ModularGroup.T : SL2Z)⁻¹) = Q := by
+  have hb := b_eq_a_of_tauOfForm_eq_rho Q hQ hrho
+  have hac := a_eq_c_of_tauOfForm_eq_rho Q hQ hrho
+  rcases Q with ⟨a, b, c⟩
+  change b = a at hb
+  change a = c at hac
+  subst b
+  subst c
+  exact transform_ST_inv_self_of_mk_eq a
+
+private theorem transform_T_inv_S_inv_eq_self_of_tau_eq_rho (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hrho : tauOfForm Q hQ = UpperHalfPlane.ρ) :
+    transform Q ((ModularGroup.T⁻¹ * ModularGroup.S : SL2Z)⁻¹) = Q := by
+  have hb := b_eq_a_of_tauOfForm_eq_rho Q hQ hrho
+  have hac := a_eq_c_of_tauOfForm_eq_rho Q hQ hrho
+  rcases Q with ⟨a, b, c⟩
+  change b = a at hb
+  change a = c at hac
+  subst b
+  subst c
+  exact transform_T_inv_S_inv_self_of_mk_eq a
+
+/-- Uniqueness statement for boundary-normalized reduced representatives. -/
+theorem eq_of_isReduced_of_properEquivalent {Q R : BinaryQuadraticForm}
+    (hQpos : Q.IsPositiveDefinite) (hQred : Q.IsReduced) (hRred : R.IsReduced)
+    (h : ProperEquivalent Q R) : Q = R := by
+  rcases h with ⟨g, rfl⟩
+  let z := tauOfForm Q hQpos
+  have hRpos : (transform Q g).IsPositiveDefinite := isPositiveDefinite_transform Q hQpos g
+  have hzfd : z ∈ ModularGroup.fd := by
+    simpa [z] using tauOfForm_mem_fd_of_isReduced Q hQpos hQred
+  have hτ : tauOfForm (transform Q g) hRpos = g⁻¹ • z := by
+    simpa [z] using tauOfForm_transform Q hQpos g hRpos
+  have hgfd : g⁻¹ • z ∈ ModularGroup.fd := by
+    simpa [hτ] using tauOfForm_mem_fd_of_isReduced (transform Q g) hRpos hRred
+  have hcases := ModularGroup.cases_of_mem_fd_smul_mem_fd (g := g⁻¹) (z := z) hzfd hgfd
+  rcases hcases with hunit | hcases
+  · rcases hunit with hginv | hginv
+    · have hg : g = 1 := by simpa using congrArg Inv.inv hginv
+      simp [hg]
+    · have hg : g = -1 := by simpa using congrArg Inv.inv hginv
+      simp [hg, transform_neg_one]
+  rcases hcases with hT | hcases
+  · rcases hT with ⟨hginv, hzre⟩
+    have hb : Q.b = Q.a := b_eq_a_of_tauOfForm_re_eq_neg_half Q hQpos (by
+      simpa [z] using hzre)
+    have hTred : (transform Q (ModularGroup.T⁻¹ : SL2Z)).IsReduced := by
+      rcases hginv with hginv | hginv
+      · have hg : g = ModularGroup.T⁻¹ := by simpa using congrArg Inv.inv hginv
+        simpa [hg] using hRred
+      · have hg : g = -ModularGroup.T⁻¹ := by simpa using congrArg Inv.inv hginv
+        simpa [hg, transform_neg] using hRred
+    exact (false_of_isReduced_transform_T_inv_of_b_eq_a Q hQpos hb hTred).elim
+  rcases hcases with hTinv | hcases
+  · rcases hTinv with ⟨_, hzre⟩
+    have hb : Q.b = -Q.a := b_eq_neg_a_of_tauOfForm_re_eq_half Q hQpos (by
+      simpa [z] using hzre)
+    exact (false_of_isReduced_of_b_eq_neg_a Q hQpos hQred hb).elim
+  rcases hcases with hS | hcases
+  · rcases hS with ⟨hginv, hnorm⟩
+    have hSred : (transform Q ModularGroup.S).IsReduced := by
+      rcases hginv with hginv | hginv
+      · have hg : g = -ModularGroup.S := by
+          simpa [ModularGroup.S_inv] using congrArg Inv.inv hginv
+        simpa [hg, transform_neg] using hRred
+      · have hg : g = ModularGroup.S := by
+          simpa [ModularGroup.S_inv] using congrArg Inv.inv hginv
+        simpa [hg] using hRred
+    have hself := transform_S_eq_self_of_reduced_of_norm_eq_one Q hQpos hQred hSred (by
+      simpa [z] using hnorm)
+    rcases hginv with hginv | hginv
+    · have hg : g = -ModularGroup.S := by
+        simpa [ModularGroup.S_inv] using congrArg Inv.inv hginv
+      simp [hg, transform_neg, hself]
+    · have hg : g = ModularGroup.S := by
+        simpa [ModularGroup.S_inv] using congrArg Inv.inv hginv
+      simp [hg, hself]
+  rcases hcases with hTS | hcases
+  · rcases hTS with ⟨_, hzrho⟩
+    have hb : Q.b = -Q.a := b_eq_neg_a_of_tauOfForm_eq_one_vadd_rho Q hQpos (by
+      simpa [z] using hzrho)
+    exact (false_of_isReduced_of_b_eq_neg_a Q hQpos hQred hb).elim
+  rcases hcases with hTinSTin | hcases
+  · rcases hTinSTin with ⟨_, hzrho⟩
+    have hb : Q.b = -Q.a := b_eq_neg_a_of_tauOfForm_eq_one_vadd_rho Q hQpos (by
+      simpa [z] using hzrho)
+    exact (false_of_isReduced_of_b_eq_neg_a Q hQpos hQred hb).elim
+  rcases hcases with hSTin | hcases
+  · rcases hSTin with ⟨_, hzrho⟩
+    have hb : Q.b = -Q.a := b_eq_neg_a_of_tauOfForm_eq_one_vadd_rho Q hQpos (by
+      simpa [z] using hzrho)
+    exact (false_of_isReduced_of_b_eq_neg_a Q hQpos hQred hb).elim
+  rcases hcases with hST | hcases
+  · rcases hST with ⟨hginv, hzrho⟩
+    have hrho : tauOfForm Q hQpos = UpperHalfPlane.ρ := by simpa [z] using hzrho
+    have hself := transform_ST_inv_eq_self_of_tau_eq_rho Q hQpos hrho
+    rcases hginv with hginv | hginv
+    · have hg : g = (ModularGroup.S * ModularGroup.T : SL2Z)⁻¹ := by
+        simpa using congrArg Inv.inv hginv
+      simpa [hg] using hself.symm
+    · have hg : g = -((ModularGroup.S * ModularGroup.T : SL2Z)⁻¹) := by
+        simpa using congrArg Inv.inv hginv
+      simpa [hg, transform_neg] using hself.symm
+  rcases hcases with hTST | hcases
+  · rcases hTST with ⟨hginv, hzrho⟩
+    have hrho : tauOfForm Q hQpos = UpperHalfPlane.ρ := by simpa [z] using hzrho
+    have hTSTred :
+        (transform Q
+          ((ModularGroup.T * ModularGroup.S * ModularGroup.T : SL2Z)⁻¹)).IsReduced := by
+      rcases hginv with hginv | hginv
+      · have hg : g = (ModularGroup.T * ModularGroup.S * ModularGroup.T : SL2Z)⁻¹ := by
+          simpa using congrArg Inv.inv hginv
+        simpa [hg] using hRred
+      · have hg : g = -((ModularGroup.T * ModularGroup.S * ModularGroup.T : SL2Z)⁻¹) := by
+          simpa using congrArg Inv.inv hginv
+        simpa [hg, transform_neg] using hRred
+    exact (false_of_isReduced_transform_TST_inv_of_tau_eq_rho Q hQpos hrho hTSTred).elim
+  rcases hcases with ⟨hginv, hzrho⟩
+  have hrho : tauOfForm Q hQpos = UpperHalfPlane.ρ := by simpa [z] using hzrho
+  have hself := transform_T_inv_S_inv_eq_self_of_tau_eq_rho Q hQpos hrho
+  rcases hginv with hginv | hginv
+  · have hg : g = (ModularGroup.T⁻¹ * ModularGroup.S : SL2Z)⁻¹ := by
+      simpa using congrArg Inv.inv hginv
+    simpa [hg] using hself.symm
+  · have hg : g = -((ModularGroup.T⁻¹ * ModularGroup.S : SL2Z)⁻¹) := by
+      simpa using congrArg Inv.inv hginv
+    simpa [hg, transform_neg] using hself.symm
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/BinaryQuadraticForms/Core/Reduction.lean
+++ b/BinaryQuadraticForms/Core/Reduction.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.Action
+import Mathlib.Data.Int.Order.Basic
+import Mathlib.Tactic.NormNum
+
+/-!
+# Reduced Binary Quadratic Forms
+
+This file defines the reduced predicate for positive definite binary quadratic
+forms in triple coordinates.
+-/
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+/-- Boundary-normalized Gauss reduction predicate for positive definite forms. -/
+def IsReduced (Q : BinaryQuadraticForm) : Prop :=
+  |Q.b| ≤ Q.a ∧ Q.a ≤ Q.c ∧
+    (|Q.b| = Q.a → 0 ≤ Q.b) ∧
+    (Q.a = Q.c → 0 ≤ Q.b)
+
+theorem isReduced_mk_iff (a b c : ℤ) :
+    IsReduced (BinaryQuadraticForm.mk a b c) ↔
+      |b| ≤ a ∧ a ≤ c ∧ (|b| = a → 0 ≤ b) ∧ (a = c → 0 ≤ b) :=
+  Iff.rfl
+
+/-- A reduced positive definite form satisfies the standard discriminant bound
+`3a² ≤ -D`. This is the arithmetic core of the finite reduced-form search. -/
+theorem three_mul_a_sq_le_neg_disc_of_isReduced (Q : BinaryQuadraticForm)
+    (hpos : Q.IsPositiveDefinite) (hred : Q.IsReduced) :
+    3 * Q.a ^ 2 ≤ -Q.disc := by
+  rcases Q with ⟨a, b, c⟩
+  rcases hpos with ⟨ha, hdisc⟩
+  rcases hred with ⟨hb_le_a, ha_le_c, _, _⟩
+  change |b| ≤ a at hb_le_a
+  change a ≤ c at ha_le_c
+  simp only [disc_mk] at hdisc ⊢
+  have hb_sq_le : b ^ 2 ≤ a ^ 2 := by
+    have hb_abs_le_abs_a : |b| ≤ |a| := by
+      simpa [abs_of_pos ha] using hb_le_a
+    exact sq_le_sq.mpr hb_abs_le_abs_a
+  have ha_mul_le : a * a ≤ a * c :=
+    mul_le_mul_of_nonneg_left ha_le_c (le_of_lt ha)
+  nlinarith
+
+/-- Nat-valued version of `three_mul_a_sq_le_neg_disc_of_isReduced`, phrased
+for the eventual `Nat.sqrt D.natAbs + 1` search bound. -/
+theorem three_mul_a_natAbs_sq_le_disc_natAbs (Q : BinaryQuadraticForm)
+    (hpos : Q.IsPositiveDefinite) (hred : Q.IsReduced) :
+    3 * Q.a.natAbs ^ 2 ≤ Q.disc.natAbs := by
+  have hbound := three_mul_a_sq_le_neg_disc_of_isReduced Q hpos hred
+  have hdisc_nonpos : Q.disc ≤ 0 := le_of_lt hpos.2
+  have ha_nonneg : 0 ≤ Q.a := le_of_lt hpos.1
+  have hcast : ((3 * Q.a.natAbs ^ 2 : ℕ) : ℤ) ≤ (Q.disc.natAbs : ℤ) := by
+    rw [Nat.cast_mul, Nat.cast_ofNat, Nat.cast_pow]
+    rw [Int.natAbs_of_nonneg ha_nonneg]
+    rw [Int.ofNat_natAbs_of_nonpos hdisc_nonpos]
+    exact hbound
+  exact_mod_cast hcast
+
+example : (BinaryQuadraticForm.mk 1 0 1).IsReduced := by
+  norm_num [IsReduced]
+
+example : (BinaryQuadraticForm.mk 1 1 1).IsReduced := by
+  norm_num [IsReduced]
+
+example : ¬ (BinaryQuadraticForm.mk 1 (-1) 1).IsReduced := by
+  intro h
+  rcases h with ⟨_, _, hb, _⟩
+  have : (|-1| : ℤ) = 1 := by norm_num
+  have hnonneg := hb this
+  norm_num at hnonneg
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/BinaryQuadraticForms/Core/UpperHalfPlane.lean
+++ b/BinaryQuadraticForms/Core/UpperHalfPlane.lean
@@ -1,0 +1,416 @@
+/-
+Copyright (c) 2026 Frankie Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frankie Wang
+-/
+
+import BinaryQuadraticForms.Core.Reduction
+import Mathlib.NumberTheory.Modular
+
+/-!
+# The Upper Half-Plane Point of a Positive Definite Binary Quadratic Form
+
+This file attaches to each positive definite binary quadratic form `(a, b, c)` of
+negative discriminant its root
+
+`τ = (-b + √(4ac - b²) · i) / (2a)`
+
+in the upper half-plane `ℍ`, and records the coordinate formulas
+
+* `(tauOfForm Q hQ).re = -b / 2a`,
+* `(tauOfForm Q hQ).im = √(4ac - b²) / 2a`,
+* `normSq (tauOfForm Q hQ) = c / a`.
+
+These feed the modular-domain proof of Gauss reduction: a positive definite form
+is reduced exactly when its point lies in the standard fundamental domain `𝒟` of
+the `SL(2, ℤ)` action on `ℍ`.
+-/
+
+namespace QuadraticNumberFields
+namespace BinaryQuadraticForm
+
+/-- The root in the upper half-plane of a positive definite form `(a, b, c)`,
+namely `τ = (-b + √(4ac - b²) · i) / (2a)`. -/
+noncomputable def tauOfForm (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    UpperHalfPlane :=
+  ⟨⟨-(Q.b : ℝ) / (2 * (Q.a : ℝ)),
+      Real.sqrt (4 * (Q.a : ℝ) * (Q.c : ℝ) - (Q.b : ℝ) ^ 2) / (2 * (Q.a : ℝ))⟩, by
+    have ha : 0 < (Q.a : ℝ) := by exact_mod_cast hQ.1
+    have hdR : (Q.b : ℝ) ^ 2 - 4 * (Q.a : ℝ) * (Q.c : ℝ) < 0 := by
+      have h := hQ.2
+      unfold disc at h
+      exact_mod_cast h
+    have hpos : (0 : ℝ) < 4 * (Q.a : ℝ) * (Q.c : ℝ) - (Q.b : ℝ) ^ 2 := by linarith
+    exact div_pos (Real.sqrt_pos.mpr hpos) (by linarith)⟩
+
+@[simp] theorem tauOfForm_re (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    (tauOfForm Q hQ).re = -(Q.b : ℝ) / (2 * (Q.a : ℝ)) := rfl
+
+@[simp] theorem tauOfForm_im (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    (tauOfForm Q hQ).im =
+      Real.sqrt (4 * (Q.a : ℝ) * (Q.c : ℝ) - (Q.b : ℝ) ^ 2) / (2 * (Q.a : ℝ)) := rfl
+
+/-- The norm-square of the upper half-plane point is `c / a`; this is the
+analytic shadow of the reduced-form bound `a ≤ c ⟺ 1 ≤ |τ|²`. -/
+theorem normSq_tauOfForm (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    Complex.normSq (tauOfForm Q hQ : ℂ) = (Q.c : ℝ) / (Q.a : ℝ) := by
+  have ha : (Q.a : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have hdR : (Q.b : ℝ) ^ 2 - 4 * (Q.a : ℝ) * (Q.c : ℝ) < 0 := by
+    have h := hQ.2
+    unfold disc at h
+    exact_mod_cast h
+  have hsq : Real.sqrt (4 * (Q.a : ℝ) * (Q.c : ℝ) - (Q.b : ℝ) ^ 2) *
+      Real.sqrt (4 * (Q.a : ℝ) * (Q.c : ℝ) - (Q.b : ℝ) ^ 2) =
+      4 * (Q.a : ℝ) * (Q.c : ℝ) - (Q.b : ℝ) ^ 2 :=
+    Real.mul_self_sqrt (by linarith)
+  simp only [Complex.normSq_apply, tauOfForm]
+  rw [div_mul_div_comm, div_mul_div_comm, hsq]
+  field_simp
+  ring
+
+/-- The upper half-plane point as an explicit complex number. -/
+theorem tauOfForm_coe (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    (tauOfForm Q hQ : ℂ) =
+      (-(Q.b : ℂ) + (Real.sqrt (4 * (Q.a : ℝ) * Q.c - (Q.b : ℝ) ^ 2) : ℝ) * Complex.I) /
+        (2 * (Q.a : ℂ)) := by
+  have ha : (Q.a : ℂ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have haR : (Q.a : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  rw [eq_div_iff (mul_ne_zero two_ne_zero ha)]
+  apply Complex.ext <;>
+    simp [tauOfForm, Complex.mul_re, Complex.mul_im] <;>
+    field_simp
+
+/-- The defining property: the form's quadratic `a X² + b X + c` vanishes at its
+upper half-plane point. -/
+theorem tauOfForm_root (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    (Q.a : ℂ) * (tauOfForm Q hQ : ℂ) ^ 2 + (Q.b : ℂ) * (tauOfForm Q hQ : ℂ) + (Q.c : ℂ) = 0 := by
+  have ha : (Q.a : ℂ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have hge : (0 : ℝ) ≤ 4 * (Q.a : ℝ) * Q.c - (Q.b : ℝ) ^ 2 := by
+    have h := hQ.2
+    unfold disc at h
+    have h' : (Q.b : ℝ) ^ 2 - 4 * (Q.a : ℝ) * Q.c < 0 := by exact_mod_cast h
+    linarith
+  have hwI : ((Real.sqrt (4 * (Q.a : ℝ) * Q.c - (Q.b : ℝ) ^ 2) : ℝ) : ℂ) ^ 2 * Complex.I ^ 2 =
+      (Q.b : ℂ) ^ 2 - 4 * Q.a * Q.c := by
+    rw [Complex.I_sq, ← Complex.ofReal_pow, Real.sq_sqrt hge]
+    push_cast
+    ring
+  rw [tauOfForm_coe]
+  field_simp
+  linear_combination hwI
+
+/-- **Uniqueness of the root in `ℍ`.** A positive definite form has exactly one
+root in the upper half-plane: the conjugate root has negative imaginary part. -/
+theorem eq_tauOfForm_of_root (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite)
+    (z : UpperHalfPlane)
+    (hz : (Q.a : ℂ) * (z : ℂ) ^ 2 + (Q.b : ℂ) * (z : ℂ) + (Q.c : ℂ) = 0) :
+    z = tauOfForm Q hQ := by
+  have hroot := tauOfForm_root Q hQ
+  have hfactor : ((z : ℂ) - (tauOfForm Q hQ : ℂ)) *
+      ((Q.a : ℂ) * ((z : ℂ) + (tauOfForm Q hQ : ℂ)) + (Q.b : ℂ)) = 0 := by
+    linear_combination hz - hroot
+  rcases mul_eq_zero.mp hfactor with h | h
+  · exact UpperHalfPlane.ext (sub_eq_zero.mp h)
+  · exfalso
+    have hzi : 0 < (z : ℂ).im := z.2
+    have hτi : 0 < (tauOfForm Q hQ : ℂ).im := (tauOfForm Q hQ).2
+    have ha_pos : 0 < (Q.a : ℝ) := by exact_mod_cast hQ.1
+    have him := congrArg Complex.im h
+    simp only [Complex.add_im, Complex.mul_im, Complex.intCast_im, Complex.intCast_re,
+      Complex.zero_im, zero_mul, add_zero] at him
+    nlinarith [him, hzi, hτi, ha_pos]
+
+/-- The `a`-coefficient of a transformed binary quadratic form. -/
+@[simp] theorem transform_a (Q : BinaryQuadraticForm) (g : SL2Z) :
+    (transform Q g).a = Q.a * g 0 0 ^ 2 + Q.b * g 0 0 * g 1 0 + Q.c * g 1 0 ^ 2 :=
+  rfl
+
+/-- The `b`-coefficient of a transformed binary quadratic form. -/
+@[simp] theorem transform_b (Q : BinaryQuadraticForm) (g : SL2Z) :
+    (transform Q g).b = 2 * Q.a * g 0 0 * g 0 1 +
+      Q.b * (g 0 0 * g 1 1 + g 0 1 * g 1 0) + 2 * Q.c * g 1 0 * g 1 1 :=
+  rfl
+
+/-- The `c`-coefficient of a transformed binary quadratic form. -/
+@[simp] theorem transform_c (Q : BinaryQuadraticForm) (g : SL2Z) :
+    (transform Q g).c = Q.a * g 0 1 ^ 2 + Q.b * g 0 1 * g 1 1 + Q.c * g 1 1 ^ 2 :=
+  rfl
+
+private theorem denom_ne_zero_sl2z (g : SL2Z) (z : UpperHalfPlane) :
+    ((g 1 0 : ℂ) * (z : ℂ) + (g 1 1 : ℂ)) ≠ 0 := by
+  have hrow : (fun j : Fin 2 => (g 1 j : ℝ)) ≠ 0 := by
+    intro h
+    have hrowZ : g 1 = 0 := by
+      funext j
+      have hj0 : (g 1 j : ℝ) = 0 := by simpa using congrFun h j
+      exact_mod_cast hj0
+    exact Matrix.SpecialLinearGroup.row_ne_zero g 1 hrowZ
+  simpa using UpperHalfPlane.linear_ne_zero z hrow
+
+private theorem transform_polynomial_eq_eval (Q : BinaryQuadraticForm) (g : SL2Z) (z : ℂ) :
+    ((transform Q g).a : ℂ) * z ^ 2 + ((transform Q g).b : ℂ) * z + (transform Q g).c =
+      (Q.a : ℂ) * ((g 0 0 : ℂ) * z + (g 0 1 : ℂ)) ^ 2 +
+        (Q.b : ℂ) * ((g 0 0 : ℂ) * z + (g 0 1 : ℂ)) *
+          ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) +
+        (Q.c : ℂ) * ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) ^ 2 := by
+  simp [transform]
+  ring
+
+/-- The upper half-plane point is contravariant for the form coordinate transform. -/
+theorem tauOfForm_transform (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite)
+    (g : SL2Z) (hQg : (transform Q g).IsPositiveDefinite) :
+    tauOfForm (transform Q g) hQg = g⁻¹ • tauOfForm Q hQ := by
+  let τH := tauOfForm Q hQ
+  let zH := g⁻¹ • τH
+  refine (eq_tauOfForm_of_root (transform Q g) hQg zH ?_).symm
+  let τ : ℂ := τH
+  let z : ℂ := zH
+  have hroot : (Q.a : ℂ) * τ ^ 2 + (Q.b : ℂ) * τ + (Q.c : ℂ) = 0 := by
+    simpa [τ, τH] using tauOfForm_root Q hQ
+  have hgz : g • zH = τH := by
+    simp [zH, τH]
+  have hmob :
+      ((g 0 0 : ℂ) * z + (g 0 1 : ℂ)) /
+        ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) = τ := by
+    have hcoe := congrArg ((↑) : UpperHalfPlane → ℂ) hgz
+    rw [UpperHalfPlane.coe_specialLinearGroup_apply] at hcoe
+    simpa [z, τ] using hcoe
+  have hden : ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) ≠ 0 := by
+    simpa [z, zH] using denom_ne_zero_sl2z g zH
+  have hlin :
+      (g 0 0 : ℂ) * z + (g 0 1 : ℂ) =
+        τ * ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) := by
+    rwa [div_eq_iff hden] at hmob
+  rw [transform_polynomial_eq_eval Q g z]
+  rw [hlin]
+  calc
+    (Q.a : ℂ) * (τ * ((g 1 0 : ℂ) * z + (g 1 1 : ℂ))) ^ 2 +
+          (Q.b : ℂ) * (τ * ((g 1 0 : ℂ) * z + (g 1 1 : ℂ))) *
+            ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) +
+        (Q.c : ℂ) * ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) ^ 2 =
+        ((g 1 0 : ℂ) * z + (g 1 1 : ℂ)) ^ 2 *
+          ((Q.a : ℂ) * τ ^ 2 + (Q.b : ℂ) * τ + (Q.c : ℂ)) := by
+      ring
+    _ = 0 := by
+      rw [hroot, mul_zero]
+
+/-- For positive definite forms of the same discriminant, the upper half-plane point
+determines the form. -/
+theorem eq_of_tauOfForm_eq_of_disc_eq (Q R : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hR : R.IsPositiveDefinite) (hdisc : Q.disc = R.disc)
+    (htau : tauOfForm Q hQ = tauOfForm R hR) : Q = R := by
+  rcases Q with ⟨a, b, c⟩
+  rcases R with ⟨A, B, C⟩
+  change 0 < a ∧ b ^ 2 - 4 * a * c < 0 at hQ
+  change 0 < A ∧ B ^ 2 - 4 * A * C < 0 at hR
+  change b ^ 2 - 4 * a * c = B ^ 2 - 4 * A * C at hdisc
+  have ha : (a : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hQ.1)
+  have hA : (A : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hR.1)
+  have ha_pos : 0 < (a : ℝ) := by exact_mod_cast hQ.1
+  have hA_pos : 0 < (A : ℝ) := by exact_mod_cast hR.1
+  have hdR : (b : ℝ) ^ 2 - 4 * (a : ℝ) * c < 0 := by
+    have h := hQ.2
+    unfold disc at h
+    exact_mod_cast h
+  have hre0 := congrArg UpperHalfPlane.re htau
+  have hre : (b : ℝ) * A = (B : ℝ) * a := by
+    simp only [tauOfForm_re] at hre0
+    field_simp [ha, hA] at hre0
+    linarith
+  have hnorm0 : (c : ℝ) / a = (C : ℝ) / A := by
+    rw [← normSq_tauOfForm (BinaryQuadraticForm.mk a b c) hQ]
+    rw [htau]
+    rw [normSq_tauOfForm]
+  have hnorm : (c : ℝ) * A = (C : ℝ) * a := by
+    field_simp [ha, hA] at hnorm0
+    linarith
+  have hdiscR : (b : ℝ) ^ 2 - 4 * (a : ℝ) * c = (B : ℝ) ^ 2 - 4 * (A : ℝ) * C := by
+    exact_mod_cast hdisc
+  have haA : (a : ℝ) = A := by
+    have hscaled : (A : ℝ) ^ 2 * ((b : ℝ) ^ 2 - 4 * (a : ℝ) * c) =
+        (a : ℝ) ^ 2 * ((B : ℝ) ^ 2 - 4 * (A : ℝ) * C) := by
+      calc
+        (A : ℝ) ^ 2 * ((b : ℝ) ^ 2 - 4 * (a : ℝ) * c)
+            = ((b : ℝ) * A) ^ 2 - 4 * (a : ℝ) * ((c : ℝ) * A) * A := by
+          ring
+        _ = ((B : ℝ) * a) ^ 2 - 4 * (a : ℝ) * ((C : ℝ) * a) * A := by
+          rw [hre, hnorm]
+        _ = (a : ℝ) ^ 2 * ((B : ℝ) ^ 2 - 4 * (A : ℝ) * C) := by
+          ring
+    have hmul :
+        ((A : ℝ) ^ 2 - (a : ℝ) ^ 2) * ((b : ℝ) ^ 2 - 4 * (a : ℝ) * c) = 0 := by
+      nlinarith [hscaled, hdiscR]
+    have hsquares : (A : ℝ) ^ 2 = (a : ℝ) ^ 2 := by
+      have hDne : (b : ℝ) ^ 2 - 4 * (a : ℝ) * c ≠ 0 := by nlinarith [hdR]
+      have hzero : (A : ℝ) ^ 2 - (a : ℝ) ^ 2 = 0 :=
+        (mul_eq_zero.mp hmul).resolve_right hDne
+      linarith
+    rcases sq_eq_sq_iff_eq_or_eq_neg.mp hsquares with h | h
+    · linarith
+    · nlinarith [h, ha_pos, hA_pos]
+  have hbB : (b : ℝ) = B := by
+    have hre' : (b : ℝ) * (a : ℝ) = (B : ℝ) * (a : ℝ) := by
+      simpa [← haA] using hre
+    exact mul_right_cancel₀ ha hre'
+  have hcC : (c : ℝ) = C := by
+    have hnorm' : (c : ℝ) * (a : ℝ) = (C : ℝ) * (a : ℝ) := by
+      simpa [← haA] using hnorm
+    exact mul_right_cancel₀ ha hnorm'
+  have haA_int : a = A := by exact_mod_cast haA
+  have hbB_int : b = B := by exact_mod_cast hbB
+  have hcC_int : c = C := by exact_mod_cast hcC
+  simp [haA_int, hbB_int, hcC_int]
+
+private theorem one_le_div_iff_int {a c : ℤ} (ha : 0 < a) :
+    (1 : ℝ) ≤ (c : ℝ) / (a : ℝ) ↔ a ≤ c := by
+  have haR : 0 < (a : ℝ) := by exact_mod_cast ha
+  constructor
+  · intro h
+    rw [le_div_iff₀ haR] at h
+    have hR : (a : ℝ) ≤ c := by nlinarith
+    exact_mod_cast hR
+  · intro h
+    have hR : (a : ℝ) ≤ c := by exact_mod_cast h
+    rw [le_div_iff₀ haR]
+    nlinarith
+
+private theorem one_lt_div_iff_int {a c : ℤ} (ha : 0 < a) :
+    (1 : ℝ) < (c : ℝ) / (a : ℝ) ↔ a < c := by
+  have haR : 0 < (a : ℝ) := by exact_mod_cast ha
+  constructor
+  · intro h
+    rw [lt_div_iff₀ haR] at h
+    have hR : (a : ℝ) < c := by nlinarith
+    exact_mod_cast hR
+  · intro h
+    have hR : (a : ℝ) < c := by exact_mod_cast h
+    rw [lt_div_iff₀ haR]
+    nlinarith
+
+private theorem abs_re_le_half_iff {a b : ℤ} (ha : 0 < a) :
+    |-(b : ℝ) / (2 * (a : ℝ))| ≤ (1 : ℝ) / 2 ↔ |b| ≤ a := by
+  have haR : 0 < (a : ℝ) := by exact_mod_cast ha
+  have hden : 0 < 2 * (a : ℝ) := by positivity
+  constructor
+  · intro h
+    rw [abs_div, abs_neg, abs_of_pos hden] at h
+    rw [div_le_iff₀ hden] at h
+    have hR : |(b : ℝ)| ≤ (a : ℝ) := by nlinarith
+    exact_mod_cast hR
+  · intro h
+    have hR : |(b : ℝ)| ≤ (a : ℝ) := by exact_mod_cast h
+    rw [abs_div, abs_neg, abs_of_pos hden]
+    rw [div_le_iff₀ hden]
+    nlinarith
+
+private theorem abs_re_lt_half_iff {a b : ℤ} (ha : 0 < a) :
+    |-(b : ℝ) / (2 * (a : ℝ))| < (1 : ℝ) / 2 ↔ |b| < a := by
+  have haR : 0 < (a : ℝ) := by exact_mod_cast ha
+  have hden : 0 < 2 * (a : ℝ) := by positivity
+  constructor
+  · intro h
+    rw [abs_div, abs_neg, abs_of_pos hden] at h
+    rw [div_lt_iff₀ hden] at h
+    have hR : |(b : ℝ)| < (a : ℝ) := by nlinarith
+    exact_mod_cast hR
+  · intro h
+    have hR : |(b : ℝ)| < (a : ℝ) := by exact_mod_cast h
+    rw [abs_div, abs_neg, abs_of_pos hden]
+    rw [div_lt_iff₀ hden]
+    nlinarith
+
+/-- Membership of `tauOfForm` in the closed modular fundamental domain is the pair of
+weak reduced-form inequalities. -/
+theorem tauOfForm_mem_fd_iff (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    tauOfForm Q hQ ∈ ModularGroup.fd ↔ |Q.b| ≤ Q.a ∧ Q.a ≤ Q.c := by
+  rw [ModularGroup.fd]
+  simp only [Set.mem_setOf_eq, normSq_tauOfForm, tauOfForm_re]
+  rw [one_le_div_iff_int hQ.1, abs_re_le_half_iff hQ.1]
+  exact and_comm
+
+/-- A reduced positive definite form has its upper half-plane point in the closed
+modular fundamental domain. -/
+theorem tauOfForm_mem_fd_of_isReduced (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hred : Q.IsReduced) :
+    tauOfForm Q hQ ∈ ModularGroup.fd :=
+  (tauOfForm_mem_fd_iff Q hQ).2 ⟨hred.1, hred.2.1⟩
+
+/-- Membership of `tauOfForm` in the open modular fundamental domain is the pair of
+strict reduced-form inequalities. -/
+theorem tauOfForm_mem_fdo_iff (Q : BinaryQuadraticForm) (hQ : Q.IsPositiveDefinite) :
+    tauOfForm Q hQ ∈ ModularGroup.fdo ↔ |Q.b| < Q.a ∧ Q.a < Q.c := by
+  rw [ModularGroup.fdo]
+  simp only [Set.mem_setOf_eq, normSq_tauOfForm, tauOfForm_re]
+  rw [one_lt_div_iff_int hQ.1, abs_re_lt_half_iff hQ.1]
+  exact and_comm
+
+private theorem isReduced_transform_T_of_neg_abs_eq_a (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hweak : |Q.b| ≤ Q.a ∧ Q.a ≤ Q.c)
+    (hbabs : |Q.b| = Q.a) (hbneg : Q.b < 0) :
+    (transform Q ModularGroup.T).IsReduced := by
+  rcases Q with ⟨a, b, c⟩
+  simp only at hQ hweak hbabs hbneg
+  have ha_pos : 0 < a := hQ.1
+  have hb_eq : b = -a := by
+    have hbabs' : -b = a := by simpa [abs_of_neg hbneg] using hbabs
+    linarith
+  have hT : transform (BinaryQuadraticForm.mk a b c) ModularGroup.T =
+      BinaryQuadraticForm.mk a (2 * a + b) (a + b + c) := by
+    ext <;> simp [ModularGroup.coe_T]
+  rw [hT, isReduced_mk_iff, hb_eq]
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · have h : |2 * a + -a| = a := by
+      rw [show 2 * a + -a = a by ring, abs_of_nonneg ha_pos.le]
+    exact h.le
+  · nlinarith [hweak.2]
+  · intro _
+    nlinarith [ha_pos]
+  · intro _
+    nlinarith [ha_pos]
+
+private theorem isReduced_transform_S_of_neg_a_eq_c (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hweak : |Q.b| ≤ Q.a ∧ Q.a ≤ Q.c)
+    (hac : Q.a = Q.c) (hbneg : Q.b < 0) :
+    (transform Q ModularGroup.S).IsReduced := by
+  rcases Q with ⟨a, b, c⟩
+  simp only at hQ hweak hac hbneg
+  have ha_pos : 0 < a := hQ.1
+  have hneg_nonneg : 0 ≤ -b := by linarith
+  have hb_abs_le : |b| ≤ a := hweak.1
+  have hS : transform (BinaryQuadraticForm.mk a b c) ModularGroup.S =
+      BinaryQuadraticForm.mk c (-b) a := by
+    ext <;> simp [ModularGroup.coe_S]
+  rw [hS, isReduced_mk_iff]
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · simpa [← hac] using hb_abs_le
+  · rw [← hac]
+  · intro _
+    exact hneg_nonneg
+  · intro _
+    exact hneg_nonneg
+
+/-- A point of a positive definite form in the closed modular fundamental domain can be
+boundary-normalized by one of the standard generators. -/
+theorem exists_isReduced_transform_of_mem_fd (Q : BinaryQuadraticForm)
+    (hQ : Q.IsPositiveDefinite) (hfd : tauOfForm Q hQ ∈ ModularGroup.fd) :
+    ∃ g : SL2Z, (transform Q g).IsReduced := by
+  have hweak : |Q.b| ≤ Q.a ∧ Q.a ≤ Q.c := (tauOfForm_mem_fd_iff Q hQ).mp hfd
+  by_cases hbadAbs : |Q.b| = Q.a ∧ Q.b < 0
+  · exact ⟨ModularGroup.T,
+      isReduced_transform_T_of_neg_abs_eq_a Q hQ hweak hbadAbs.1 hbadAbs.2⟩
+  · by_cases hbadC : Q.a = Q.c ∧ Q.b < 0
+    · exact ⟨ModularGroup.S,
+        isReduced_transform_S_of_neg_a_eq_c Q hQ hweak hbadC.1 hbadC.2⟩
+    · refine ⟨1, ?_⟩
+      have hred : Q.IsReduced := by
+        refine ⟨hweak.1, hweak.2, ?_, ?_⟩
+        · intro hbabs
+          by_contra hbnonneg
+          exact hbadAbs ⟨hbabs, lt_of_not_ge hbnonneg⟩
+        · intro hac
+          by_contra hbnonneg
+          exact hbadC ⟨hac, lt_of_not_ge hbnonneg⟩
+      simpa using hred
+
+end BinaryQuadraticForm
+end QuadraticNumberFields

--- a/QuadraticNumberFields.lean
+++ b/QuadraticNumberFields.lean
@@ -44,6 +44,8 @@ import BinaryQuadraticForms.Core.Basic
 import BinaryQuadraticForms.Core.Action
 import BinaryQuadraticForms.Core.Class
 import BinaryQuadraticForms.Core.QuadraticFormBridge
+import BinaryQuadraticForms.Core.Enumeration
+import BinaryQuadraticForms.Core.Reduction
 import QuadraticNumberFields.ClassNumber
 import QuadraticNumberFields.Examples.SqrtNeg5.Ideals
 import QuadraticNumberFields.Examples.SqrtNeg5.RamificationInertia


### PR DESCRIPTION
## Summary

- Add reduction and upper-half-plane uniqueness for binary quadratic forms.
- Package reduced proper classes and enumerate reduced positive-definite forms.
- Update the `BinaryQuadraticForms` root and stable QNF entrypoint for this layer.

## Stack

Base: `bqf-core`. This is stack PR 2. Next branch: `bqf-gauss-composition`.

## Verification

- `git diff --check`
- `lake build BinaryQuadraticForms`
- `lake build`