### PR TITLE
Extend genus theory sieve to the odd discriminant branch

### DIFF
--- a/QuadraticNumberFields/ClassGroup/GenusTheory.lean
+++ b/QuadraticNumberFields/ClassGroup/GenusTheory.lean
@@ -714,5 +714,29 @@ theorem classNumber_eq_one_imp_discriminant_prime_shape
     genus_divisibility_of_squareClassSubgroup_quotient_card d hgenus
   exact discriminant_prime_shape_of_genus_divisibility d hd hdiv h
 
+/-- In the odd field-discriminant branch, the genus-theory sieve leaves only
+the prime-discriminant family: `d = -p` for a rational prime `p ≡ 3 (mod 4)`.
+
+This is the part of Cox Theorem 12.34 where genus theory is used.  The even
+field-discriminant branch is handled separately by Landau's reduced-form
+classification of the discriminants `-4n` with class number one. -/
+theorem classNumber_eq_one_imp_exists_prime_of_odd_discr
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd : d < 0)
+    (hodd : RingOfIntegers.discrFormula d % 2 ≠ 0)
+    (hgenus : genusFormula d)
+    (h : NumberField.classNumber (Qsqrtd (d : ℚ)) = 1) :
+    ∃ p : ℕ, Nat.Prime p ∧ p % 4 = 3 ∧ d = -(p : ℤ) := by
+  rcases classNumber_eq_one_imp_discriminant_prime_shape d hd hgenus h with
+    hneg1 | hneg2 | hprime
+  · exfalso
+    subst hneg1
+    exact hodd (by
+      norm_num [RingOfIntegers.discrFormula, RingOfIntegers.discrFormula_of_mod_four_ne_one])
+  · exfalso
+    subst hneg2
+    exact hodd (by
+      norm_num [RingOfIntegers.discrFormula, RingOfIntegers.discrFormula_of_mod_four_ne_one])
+  · exact hprime
+
 end ClassGroup
 end QuadraticNumberFields

--- a/QuadraticNumberFields/ClassGroup/GenusTheory.lean
+++ b/QuadraticNumberFields/ClassGroup/GenusTheory.lean
@@ -59,6 +59,33 @@ theorem card_oddPrimeDiscriminantDivisors_le (d : ℤ) :
   dsimp [oddPrimeDiscriminantDivisors, primeDiscriminantFactorCount]
   exact Finset.card_filter_le _ _
 
+/-- If the field discriminant is odd, the odd discriminant divisors are all
+prime discriminant divisors. -/
+theorem oddPrimeDiscriminantDivisors_eq_primeFactors_of_discr_odd
+    (d : ℤ) (hodd : RingOfIntegers.discrFormula d % 2 ≠ 0) :
+    oddPrimeDiscriminantDivisors d =
+      (RingOfIntegers.discrFormula d).natAbs.primeFactors := by
+  apply Finset.filter_true_of_mem
+  intro p hp hp2
+  subst hp2
+  have hmem := Nat.mem_primeFactors.mp hp
+  have h2dvd_nat : 2 ∣ (RingOfIntegers.discrFormula d).natAbs := hmem.2.1
+  have h2dvd_int : (2 : ℤ) ∣ RingOfIntegers.discrFormula d := by
+    rw [← Int.dvd_natAbs]
+    exact_mod_cast h2dvd_nat
+  obtain ⟨k, hk⟩ := h2dvd_int
+  apply hodd
+  rw [hk]
+  omega
+
+/-- In the odd field-discriminant branch, the number of odd discriminant divisors
+is exactly the genus-theory prime-discriminant count. -/
+theorem card_oddPrimeDiscriminantDivisors_eq_primeDiscriminantFactorCount_of_discr_odd
+    (d : ℤ) (hodd : RingOfIntegers.discrFormula d % 2 ≠ 0) :
+    (oddPrimeDiscriminantDivisors d).card = primeDiscriminantFactorCount d := by
+  rw [oddPrimeDiscriminantDivisors_eq_primeFactors_of_discr_odd d hodd]
+  rfl
+
 /-- Characterization of membership in `oddPrimeDiscriminantDivisors`. -/
 theorem mem_oddPrimeDiscriminantDivisors_iff (d : ℤ) (p : ℕ) :
     p ∈ oddPrimeDiscriminantDivisors d ↔
@@ -554,6 +581,256 @@ noncomputable def squareClassSubgroup (d : ℤ) [Fact (Squarefree d)] [Fact (d �
     Subgroup (ClassGroup (𝓞 (Qsqrtd (d : ℚ)))) :=
   (powMonoidHom (α := ClassGroup (𝓞 (Qsqrtd (d : ℚ)))) 2).range
 
+/-! ## Squares lie in the principal genus -/
+
+/-- The prime-to-`p` raw genus character takes values of order dividing two. -/
+theorem genusCharacterRawUnit_sq_eq_one
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (p : ℕ) [Fact p.Prime]
+    (I : idealsPrimeToNormSubmonoid d p) :
+    genusCharacterRawUnit d p I ^ 2 = 1 := by
+  ext
+  exact genusCharacterRaw_sq_eq_one_of_norm_not_dvd d p I I.2
+
+/-- A descended genus character takes values of order dividing two on every class. -/
+theorem genusCharacterOfPrincipalMultiplierData_sq_eq_one
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (p : ℕ) [Fact p.Prime]
+    (hd_neg : d < 0) (hp_disc : p ∈ oddPrimeDiscriminantDivisors d)
+    (hsurj : Function.Surjective (mk0OnPrimeToNormIdeals d p))
+    (hdata : HasPrimeToNormPrincipalMultiplierData d p)
+    (C : ClassGroup (𝓞 (Qsqrtd (d : ℚ)))) :
+    genusCharacterOfPrincipalMultiplierData d p hd_neg hp_disc hsurj hdata C ^ 2 = 1 := by
+  let I := Classical.choose (hsurj C)
+  have hI : mk0OnPrimeToNormIdeals d p I = C := Classical.choose_spec (hsurj C)
+  have happly := genusCharacterOfPrincipalMultiplierData_apply_mk0OnPrimeToNormIdeals
+    d p hd_neg hp_disc hsurj hdata I
+  rw [hI] at happly
+  rw [happly]
+  exact genusCharacterRawUnit_sq_eq_one d p I
+
+/-- Every descended genus character kills the square-class subgroup `Cl²`. This is the
+formal `Cl² ⊆ principal genus` direction for the odd-prime genus characters. -/
+theorem squareClassSubgroup_le_genusCharacterOfPrincipalMultiplierData_ker
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (p : ℕ) [Fact p.Prime]
+    (hd_neg : d < 0) (hp_disc : p ∈ oddPrimeDiscriminantDivisors d)
+    (hsurj : Function.Surjective (mk0OnPrimeToNormIdeals d p))
+    (hdata : HasPrimeToNormPrincipalMultiplierData d p) :
+    squareClassSubgroup d ≤
+      (genusCharacterOfPrincipalMultiplierData d p hd_neg hp_disc hsurj hdata).ker := by
+  intro C hC
+  rcases hC with ⟨D, rfl⟩
+  rw [MonoidHom.mem_ker, powMonoidHom_apply, map_pow]
+  exact genusCharacterOfPrincipalMultiplierData_sq_eq_one d p hd_neg hp_disc hsurj hdata D
+
+/-- A descended odd-prime genus character as a character on the principal-genus
+quotient `Cl / Cl²`. -/
+noncomputable def genusCharacterOnSquareClassQuotient
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (p : ℕ) [Fact p.Prime]
+    (hd_neg : d < 0) (hp_disc : p ∈ oddPrimeDiscriminantDivisors d)
+    (hsurj : Function.Surjective (mk0OnPrimeToNormIdeals d p))
+    (hdata : HasPrimeToNormPrincipalMultiplierData d p) :
+    ClassGroup (𝓞 (Qsqrtd (d : ℚ))) ⧸ squareClassSubgroup d →* ℤˣ :=
+  QuotientGroup.lift (squareClassSubgroup d)
+    (genusCharacterOfPrincipalMultiplierData d p hd_neg hp_disc hsurj hdata)
+    (squareClassSubgroup_le_genusCharacterOfPrincipalMultiplierData_ker
+      d p hd_neg hp_disc hsurj hdata)
+
+/-- The character on `Cl / Cl²` agrees with the descended genus character after
+composing with the quotient map. -/
+theorem genusCharacterOnSquareClassQuotient_apply
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (p : ℕ) [Fact p.Prime]
+    (hd_neg : d < 0) (hp_disc : p ∈ oddPrimeDiscriminantDivisors d)
+    (hsurj : Function.Surjective (mk0OnPrimeToNormIdeals d p))
+    (hdata : HasPrimeToNormPrincipalMultiplierData d p)
+    (C : ClassGroup (𝓞 (Qsqrtd (d : ℚ)))) :
+    genusCharacterOnSquareClassQuotient d p hd_neg hp_disc hsurj hdata C =
+      genusCharacterOfPrincipalMultiplierData d p hd_neg hp_disc hsurj hdata C := by
+  rfl
+
+/-- Ideal-avoidance data needed to construct all odd-prime genus characters.
+
+The two fields are the remaining local inputs not supplied by the raw Legendre-symbol
+calculation: every class must have a representative whose norm is prime to `p`, and
+equal such representatives must have principal multipliers still prime to `p`. -/
+structure OddGenusCharacterData (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] where
+  /-- Every ideal class has a representative whose norm is prime to `p`. -/
+  surjective : ∀ (p : ℕ) [Fact p.Prime], p ∈ oddPrimeDiscriminantDivisors d →
+    Function.Surjective (mk0OnPrimeToNormIdeals d p)
+  /-- Equal prime-to-`p` representatives have a compatible principal multiplier
+  whose norm stays prime to `p`. -/
+  principalMultiplier :
+    ∀ (p : ℕ) [Fact p.Prime], p ∈ oddPrimeDiscriminantDivisors d →
+      HasPrimeToNormPrincipalMultiplierData d p
+
+/-- The product of all odd-prime genus characters on the principal-genus quotient.
+
+The remaining genus-theory relation and independence statements identify the image of
+this map with the sign vectors satisfying the single product relation. -/
+noncomputable def oddGenusCharacterProductOnSquareClassQuotient
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd_neg : d < 0)
+    (hdata : OddGenusCharacterData d) :
+    ClassGroup (𝓞 (Qsqrtd (d : ℚ))) ⧸ squareClassSubgroup d →*
+      ((P : {p // p ∈ oddPrimeDiscriminantDivisors d}) → ℤˣ) :=
+  Pi.monoidHom fun P => by
+    haveI : Fact P.1.Prime := ⟨prime_of_mem_oddPrimeDiscriminantDivisors P.2⟩
+    exact genusCharacterOnSquareClassQuotient d P.1 hd_neg P.2
+      (hdata.surjective P.1 P.2) (hdata.principalMultiplier P.1 P.2)
+
+/-- The product character evaluates componentwise to the corresponding odd-prime
+genus character. -/
+theorem oddGenusCharacterProductOnSquareClassQuotient_apply
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd_neg : d < 0)
+    (hdata : OddGenusCharacterData d)
+    (C : ClassGroup (𝓞 (Qsqrtd (d : ℚ))) ⧸ squareClassSubgroup d)
+    (P : {p // p ∈ oddPrimeDiscriminantDivisors d}) :
+    oddGenusCharacterProductOnSquareClassQuotient d hd_neg hdata C P = by
+      haveI : Fact P.1.Prime := ⟨prime_of_mem_oddPrimeDiscriminantDivisors P.2⟩
+      exact genusCharacterOnSquareClassQuotient d P.1 hd_neg P.2
+        (hdata.surjective P.1 P.2) (hdata.principalMultiplier P.1 P.2) C := by
+  rfl
+
+/-- Product of all coordinates of an odd-prime sign vector. -/
+noncomputable def oddGenusSignProductHom (d : ℤ) :
+    (((P : {p // p ∈ oddPrimeDiscriminantDivisors d}) → ℤˣ) →* ℤˣ) where
+  toFun v := Finset.univ.prod fun P => v P
+  map_one' := by simp
+  map_mul' v w := by
+    change Finset.univ.prod (fun P => v P * w P) =
+      Finset.univ.prod (fun P => v P) * Finset.univ.prod (fun P => w P)
+    rw [Finset.prod_mul_distrib]
+
+/-- The subgroup of sign vectors whose component product is `1`. In the odd
+fundamental-discriminant branch this is the expected target of the genus-character map:
+all odd-prime genus characters satisfy one product relation. -/
+noncomputable def oddGenusSignRelationSubgroup (d : ℤ) :
+    Subgroup ((P : {p // p ∈ oddPrimeDiscriminantDivisors d}) → ℤˣ) :=
+  (oddGenusSignProductHom d).ker
+
+/-- Membership in the odd-genus sign relation subgroup is the product-one relation. -/
+theorem mem_oddGenusSignRelationSubgroup_iff (d : ℤ)
+    (v : (P : {p // p ∈ oddPrimeDiscriminantDivisors d}) → ℤˣ) :
+    v ∈ oddGenusSignRelationSubgroup d ↔ Finset.univ.prod (fun P => v P) = 1 :=
+  Iff.rfl
+
+/-- If there is at least one odd discriminant divisor, the coordinate-product map
+from sign vectors to `ℤˣ` is surjective. -/
+theorem oddGenusSignProductHom_surjective_of_nonempty
+    (d : ℤ) (hS : (oddPrimeDiscriminantDivisors d).Nonempty) :
+    Function.Surjective (oddGenusSignProductHom d) := by
+  classical
+  obtain ⟨p, hp⟩ := hS
+  let P : {p // p ∈ oddPrimeDiscriminantDivisors d} := ⟨p, hp⟩
+  intro u
+  refine ⟨fun Q => if Q = P then u else 1, ?_⟩
+  dsimp [oddGenusSignProductHom]
+  rw [Finset.prod_ite_eq']
+  simp
+
+/-- The full odd-prime sign-vector space has cardinality `2 ^ #S`, where `S` is
+the set of odd discriminant divisors. -/
+theorem card_oddGenusSignVectors (d : ℤ) :
+    Nat.card ((P : {p // p ∈ oddPrimeDiscriminantDivisors d}) → ℤˣ) =
+      2 ^ (oddPrimeDiscriminantDivisors d).card := by
+  classical
+  rw [Nat.card_eq_fintype_card, Fintype.card_fun]
+  rw [Fintype.card_units_int, Fintype.card_coe]
+
+/-- If the odd discriminant-divisor set is nonempty, the product-one sign
+relation subgroup has cardinality `2 ^ (#S - 1)`. -/
+theorem card_oddGenusSignRelationSubgroup_of_nonempty
+    (d : ℤ) (hS : (oddPrimeDiscriminantDivisors d).Nonempty) :
+    Nat.card (oddGenusSignRelationSubgroup d) =
+      2 ^ ((oddPrimeDiscriminantDivisors d).card - 1) := by
+  classical
+  have hsurj := oddGenusSignProductHom_surjective_of_nonempty d hS
+  have hindex : (oddGenusSignRelationSubgroup d).index = 2 := by
+    calc
+      (oddGenusSignRelationSubgroup d).index = Nat.card (oddGenusSignProductHom d).range := by
+        rw [oddGenusSignRelationSubgroup, Subgroup.index_ker]
+      _ = Nat.card (⊤ : Subgroup ℤˣ) := by
+        rw [MonoidHom.range_eq_top.mpr hsurj]
+      _ = 2 := by
+        rw [Subgroup.card_top, Nat.card_eq_fintype_card, Fintype.card_units_int]
+  have hmul := (oddGenusSignRelationSubgroup d).card_mul_index
+  rw [hindex, card_oddGenusSignVectors d] at hmul
+  have hcard_pos : 0 < (oddPrimeDiscriminantDivisors d).card := Finset.card_pos.mpr hS
+  have hpow : 2 ^ (oddPrimeDiscriminantDivisors d).card =
+      2 ^ ((oddPrimeDiscriminantDivisors d).card - 1) * 2 := by
+    have hsucc : (oddPrimeDiscriminantDivisors d).card =
+        ((oddPrimeDiscriminantDivisors d).card - 1) + 1 := by omega
+    calc
+      2 ^ (oddPrimeDiscriminantDivisors d).card =
+          2 ^ (((oddPrimeDiscriminantDivisors d).card - 1) + 1) := by rw [← hsucc]
+      _ = 2 ^ ((oddPrimeDiscriminantDivisors d).card - 1) * 2 := by rw [pow_succ]
+  rw [hpow] at hmul
+  exact Nat.mul_right_cancel (by norm_num : 0 < 2) hmul
+
+/-- The product-one sign relation subgroup has cardinality `2 ^ (#S - 1)`, also
+covering the empty-index case by natural-number subtraction. -/
+theorem card_oddGenusSignRelationSubgroup (d : ℤ) :
+    Nat.card (oddGenusSignRelationSubgroup d) =
+      2 ^ ((oddPrimeDiscriminantDivisors d).card - 1) := by
+  classical
+  by_cases hS : (oddPrimeDiscriminantDivisors d).Nonempty
+  · exact card_oddGenusSignRelationSubgroup_of_nonempty d hS
+  · have hempty : oddPrimeDiscriminantDivisors d = ∅ := Finset.not_nonempty_iff_eq_empty.mp hS
+    have hrel_top : oddGenusSignRelationSubgroup d = ⊤ := by
+      haveI : IsEmpty {p // p ∈ oddPrimeDiscriminantDivisors d} := by
+        refine ⟨?_⟩
+        intro P
+        have hp_empty : P.1 ∈ (∅ : Finset ℕ) := by
+          simpa [hempty] using P.property
+        simp at hp_empty
+      ext v
+      simp [oddGenusSignRelationSubgroup, oddGenusSignProductHom]
+    rw [hrel_top, Subgroup.card_top, card_oddGenusSignVectors d, hempty]
+    norm_num
+
+/-- In the odd field-discriminant branch, the product-one sign relation subgroup
+has the genus-theory cardinality `2 ^ (t - 1)`. -/
+theorem card_oddGenusSignRelationSubgroup_of_discr_odd
+    (d : ℤ) (hodd : RingOfIntegers.discrFormula d % 2 ≠ 0) :
+    Nat.card (oddGenusSignRelationSubgroup d) =
+      2 ^ (primeDiscriminantFactorCount d - 1) := by
+  rw [card_oddGenusSignRelationSubgroup,
+    card_oddPrimeDiscriminantDivisors_eq_primeDiscriminantFactorCount_of_discr_odd d hodd]
+
+/-- The product-relation assertion for the odd-prime genus characters. This is one
+of the remaining genus-theory inputs after constructing the individual characters. -/
+def oddGenusProductRelation
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd_neg : d < 0)
+    (hdata : OddGenusCharacterData d) : Prop :=
+  ∀ C : ClassGroup (𝓞 (Qsqrtd (d : ℚ))) ⧸ squareClassSubgroup d,
+    oddGenusCharacterProductOnSquareClassQuotient d hd_neg hdata C ∈
+      oddGenusSignRelationSubgroup d
+
+/-- The product of the odd-prime genus characters, with codomain restricted to the
+single-relation sign subgroup. -/
+noncomputable def oddGenusCharacterProductToRelationSubgroup
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd_neg : d < 0)
+    (hdata : OddGenusCharacterData d)
+    (hrel : oddGenusProductRelation d hd_neg hdata) :
+    ClassGroup (𝓞 (Qsqrtd (d : ℚ))) ⧸ squareClassSubgroup d →*
+      oddGenusSignRelationSubgroup d where
+  toFun C := ⟨oddGenusCharacterProductOnSquareClassQuotient d hd_neg hdata C, hrel C⟩
+  map_one' := by
+    ext P
+    simp
+  map_mul' C D := by
+    ext P
+    simp
+
+/-- The relation-subgroup-valued product character forgets to the raw product
+character. -/
+theorem oddGenusCharacterProductToRelationSubgroup_apply
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd_neg : d < 0)
+    (hdata : OddGenusCharacterData d)
+    (hrel : oddGenusProductRelation d hd_neg hdata)
+    (C : ClassGroup (𝓞 (Qsqrtd (d : ℚ))) ⧸ squareClassSubgroup d) :
+    (oddGenusCharacterProductToRelationSubgroup d hd_neg hdata hrel C :
+      (P : {p // p ∈ oddPrimeDiscriminantDivisors d}) → ℤˣ) =
+      oddGenusCharacterProductOnSquareClassQuotient d hd_neg hdata C := by
+  rfl
+
 /-- The standard genus formula for the principal-genus quotient
 `Cl(𝓞(ℚ(√d))) / Cl(𝓞(ℚ(√d)))²`: its cardinality is `2 ^ (t - 1)`, where `t` is the
 number of prime-discriminant factors. In the literature this is the statement that
@@ -562,6 +839,35 @@ or equivalently `#Cl[2] = 2 ^ (t - 1)`. -/
 def genusFormula (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] : Prop :=
   Nat.card (ClassGroup (𝓞 (Qsqrtd (d : ℚ))) ⧸ squareClassSubgroup d) =
     2 ^ (primeDiscriminantFactorCount d - 1)
+
+/-- If the relation-subgroup-valued odd genus-character product is bijective and
+the relation subgroup has the expected cardinality, then the standard genus
+formula follows. -/
+theorem genusFormula_of_oddGenusCharacterProductToRelationSubgroup_bijective
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd_neg : d < 0)
+    (hdata : OddGenusCharacterData d)
+    (hrel : oddGenusProductRelation d hd_neg hdata)
+    (hbij :
+      Function.Bijective (oddGenusCharacterProductToRelationSubgroup d hd_neg hdata hrel))
+    (hcard : Nat.card (oddGenusSignRelationSubgroup d) =
+      2 ^ (primeDiscriminantFactorCount d - 1)) :
+    genusFormula d := by
+  dsimp [genusFormula]
+  rw [← hcard]
+  exact Nat.card_congr (Equiv.ofBijective _ hbij)
+
+/-- In the odd field-discriminant branch, bijectivity of the relation-subgroup-valued
+odd genus-character product implies the standard genus formula. -/
+theorem genusFormula_of_oddGenusCharacterProductToRelationSubgroup_bijective_of_discr_odd
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (hd_neg : d < 0)
+    (hodd : RingOfIntegers.discrFormula d % 2 ≠ 0)
+    (hdata : OddGenusCharacterData d)
+    (hrel : oddGenusProductRelation d hd_neg hdata)
+    (hbij :
+      Function.Bijective (oddGenusCharacterProductToRelationSubgroup d hd_neg hdata hrel)) :
+    genusFormula d :=
+  genusFormula_of_oddGenusCharacterProductToRelationSubgroup_bijective d hd_neg hdata hrel hbij
+    (card_oddGenusSignRelationSubgroup_of_discr_odd d hodd)
 
 /-- If the principal-genus quotient has the standard genus-theory cardinality,
 then the standard genus-theory divisibility follows from Lagrange's theorem. -/

--- a/QuadraticNumberFields/ClassGroup/GenusTheory.lean
+++ b/QuadraticNumberFields/ClassGroup/GenusTheory.lean
@@ -730,12 +730,12 @@ theorem classNumber_eq_one_imp_exists_prime_of_odd_discr
     hneg1 | hneg2 | hprime
   · exfalso
     subst hneg1
-    exact hodd (by
-      norm_num [RingOfIntegers.discrFormula, RingOfIntegers.discrFormula_of_mod_four_ne_one])
+    have hd4 := (RingOfIntegers.discrFormula_odd_iff_mod_four_eq_one (-1)).mp hodd
+    norm_num at hd4
   · exfalso
     subst hneg2
-    exact hodd (by
-      norm_num [RingOfIntegers.discrFormula, RingOfIntegers.discrFormula_of_mod_four_ne_one])
+    have hd4 := (RingOfIntegers.discrFormula_odd_iff_mod_four_eq_one (-2)).mp hodd
+    norm_num at hd4
   · exact hprime
 
 end ClassGroup

--- a/QuadraticNumberFields/ClassGroup/GenusTheory.lean
+++ b/QuadraticNumberFields/ClassGroup/GenusTheory.lean
@@ -284,6 +284,18 @@ noncomputable def genusCharacterOfPrimeToNormDescent
         exact map_mul (genusCharacterRawOnPrimeToNormIdeals d p)
           (Classical.choose (hsurj C)) (Classical.choose (hsurj D))
 
+/-- The descended genus character agrees with the raw genus character on the
+class represented by a prime-to-`p` ideal. -/
+theorem genusCharacterOfPrimeToNormDescent_apply_mk0OnPrimeToNormIdeals
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (p : ℕ) [Fact p.Prime]
+    (hsurj : Function.Surjective (mk0OnPrimeToNormIdeals d p))
+    (hdesc : genusCharacterRawDescendsOnPrimeToNormIdeals d p)
+    (I : idealsPrimeToNormSubmonoid d p) :
+    genusCharacterOfPrimeToNormDescent d p hsurj hdesc (mk0OnPrimeToNormIdeals d p I) =
+      genusCharacterRawUnit d p I := by
+  exact hdesc (Classical.choose (hsurj (mk0OnPrimeToNormIdeals d p I))) I
+    (Classical.choose_spec (hsurj (mk0OnPrimeToNormIdeals d p I)))
+
 /-- From `p ∈ oddPrimeDiscriminantDivisors d` (so `p` is an odd prime), deduce
 `(p : ℤ) ∣ d`. For `d % 4 = 1`, `discrFormula d = d` directly. For `d % 4 ≠ 1`,
 `discrFormula d = 4*d`; since `p` is an odd prime, `p ∤ 4`, so `p ∣ d`. -/
@@ -482,6 +494,21 @@ noncomputable def genusCharacterOfPrincipalMultiplierData
   genusCharacterOfPrimeToNormDescent d p hsurj
     (genusCharacterRawDescendsOnPrimeToNormIdeals_of_principalMultiplierData d p hd_neg hp_disc
       hdata)
+
+/-- The genus character obtained from principal-multiplier descent agrees with
+the raw genus character on prime-to-`p` ideal representatives. -/
+theorem genusCharacterOfPrincipalMultiplierData_apply_mk0OnPrimeToNormIdeals
+    (d : ℤ) [Fact (Squarefree d)] [Fact (d ≠ 1)] (p : ℕ) [Fact p.Prime]
+    (hd_neg : d < 0) (hp_disc : p ∈ oddPrimeDiscriminantDivisors d)
+    (hsurj : Function.Surjective (mk0OnPrimeToNormIdeals d p))
+    (hdata : HasPrimeToNormPrincipalMultiplierData d p)
+    (I : idealsPrimeToNormSubmonoid d p) :
+    genusCharacterOfPrincipalMultiplierData d p hd_neg hp_disc hsurj hdata
+        (mk0OnPrimeToNormIdeals d p I) =
+      genusCharacterRawUnit d p I := by
+  exact genusCharacterOfPrimeToNormDescent_apply_mk0OnPrimeToNormIdeals d p hsurj
+    (genusCharacterRawDescendsOnPrimeToNormIdeals_of_principalMultiplierData d p hd_neg hp_disc
+      hdata) I
 
 /-! ## Class-number-one sieve (continued) -/
 

--- a/QuadraticNumberFields/RingOfIntegers/Discriminant.lean
+++ b/QuadraticNumberFields/RingOfIntegers/Discriminant.lean
@@ -83,6 +83,19 @@ theorem discrFormula_emod_four_eq_zero_or_one (d : ℤ) :
   · left
     rw [discrFormula_of_mod_four_ne_one h, Int.mul_emod_right]
 
+/-- The closed quadratic discriminant formula is odd exactly in the half-integral
+branch `d % 4 = 1`. -/
+theorem discrFormula_odd_iff_mod_four_eq_one (d : ℤ) :
+    discrFormula d % 2 ≠ 0 ↔ d % 4 = 1 := by
+  constructor
+  · intro hodd
+    by_contra hd4
+    rw [discrFormula_of_mod_four_ne_one hd4] at hodd
+    exact hodd (by omega)
+  · intro hd4
+    rw [discrFormula_of_mod_four_eq_one hd4]
+    omega
+
 /-- **Discriminant of `Q(√d)` when `d % 4 ≠ 1`.**
 
 When `d % 4 ≠ 1`, the ring of integers is `𝓞 ≅ ℤ[√d]` with ℤ-basis `{1, √d}`,


### PR DESCRIPTION
## Summary
- Add the odd-discriminant version of the prime-discriminant count and connect it to the genus-theory divisor set.
- Prove the descended genus characters agree with the raw characters on prime-to-`p` representatives and square to `1`.
- Package the odd-prime genus characters into a product map landing in the product-one sign relation subgroup.
- Derive the genus formula from bijectivity of that map, and use it to isolate the `d = -p` shape in the odd discriminant class-number-one case.
- Add the discriminant parity lemma needed to separate the odd and even branches cleanly.

## Testing
- Not run (not requested).