### PR TITLE
Bump package version to 0.2.0

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "QuadraticNumberFields"
-version = "0.1.0"
+version = "0.2.0"
 keywords = ["math", "number-theory", "quadratic-fields"]
 defaultTargets = [
   "QNFMathlib",


### PR DESCRIPTION
## Summary

Bump the Lake package version from `0.1.0` to `0.2.0`.

## Release alignment

This release establishes `0.2.0` as the package version recorded in `lakefile.toml` and should be paired with the GitHub release tag `v0.2.0`.

Older GitHub releases have inconsistent numbering relative to the Lake package version; they are left intact as historical releases rather than rewritten.

## Checks

- Skipped additional local verification after request.
- Earlier in this run, `lake build` completed successfully before verification was skipped.
